### PR TITLE
Add dashboard analytics endpoints

### DIFF
--- a/OrbitsCameraProject.API/Controllers/DashboardController.cs
+++ b/OrbitsCameraProject.API/Controllers/DashboardController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using Orbits.GeneralProject.BLL.DashboardService;
+
+namespace OrbitsProject.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class DashboardController : AppBaseController
+    {
+        private readonly IDashboardBLL _dashboardBLL;
+
+        public DashboardController(IDashboardBLL dashboardBLL)
+        {
+            _dashboardBLL = dashboardBLL;
+        }
+
+        [HttpGet("summary")]
+        public async Task<IActionResult> GetSummary()
+        {
+            return Ok(await _dashboardBLL.GetSummaryAsync());
+        }
+
+        [HttpGet("repeat-customers")]
+        public async Task<IActionResult> GetRepeatCustomers([FromQuery] int months = 6)
+        {
+            return Ok(await _dashboardBLL.GetRepeatCustomerRateAsync(months));
+        }
+
+        [HttpGet("monthly-revenue")]
+        public async Task<IActionResult> GetMonthlyRevenue([FromQuery] int months = 6)
+        {
+            return Ok(await _dashboardBLL.GetMonthlyRevenueAsync(months));
+        }
+
+        [HttpGet("revenue-by-currency")]
+        public async Task<IActionResult> GetRevenueByCurrency([FromQuery] DateTime? startDate = null, [FromQuery] DateTime? endDate = null)
+        {
+            return Ok(await _dashboardBLL.GetRevenueByCurrencyAsync(startDate, endDate));
+        }
+    }
+}

--- a/OrbitsGeneralProject.BLL/DashboardService/DashboardBLL.cs
+++ b/OrbitsGeneralProject.BLL/DashboardService/DashboardBLL.cs
@@ -1,0 +1,494 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.Core.Entities;
+using Orbits.GeneralProject.DTO.Dashboard;
+using Orbits.GeneralProject.Repositroy.Base;
+using System.Globalization;
+
+namespace Orbits.GeneralProject.BLL.DashboardService
+{
+    public class DashboardBLL : BaseBLL, IDashboardBLL
+    {
+        private static readonly Dictionary<int, string> CurrencyLabels = new()
+        {
+            { 1, "EGP" },
+            { 2, "SAR" },
+            { 3, "USD" }
+        };
+
+        private readonly IRepository<StudentPayment> _studentPaymentRepository;
+        private readonly IRepository<Student> _studentRepository;
+        private readonly IRepository<Teacher> _teacherRepository;
+        private readonly IRepository<CircleReport> _circleReportRepository;
+        private readonly IRepository<TeacherSallary> _teacherSalaryRepository;
+        private readonly IRepository<ManagerSallary> _managerSalaryRepository;
+
+        public DashboardBLL(
+            IMapper mapper,
+            IRepository<StudentPayment> studentPaymentRepository,
+            IRepository<Student> studentRepository,
+            IRepository<Teacher> teacherRepository,
+            IRepository<CircleReport> circleReportRepository,
+            IRepository<TeacherSallary> teacherSalaryRepository,
+            IRepository<ManagerSallary> managerSalaryRepository) : base(mapper)
+        {
+            _studentPaymentRepository = studentPaymentRepository;
+            _studentRepository = studentRepository;
+            _teacherRepository = teacherRepository;
+            _circleReportRepository = circleReportRepository;
+            _teacherSalaryRepository = teacherSalaryRepository;
+            _managerSalaryRepository = managerSalaryRepository;
+        }
+
+        public async Task<IResponse<DashboardSummaryDto>> GetSummaryAsync()
+        {
+            Response<DashboardSummaryDto> output = new();
+            try
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                DateTime currentMonthStart = new DateTime(utcNow.Year, utcNow.Month, 1);
+                DateTime nextMonthStart = currentMonthStart.AddMonths(1);
+                DateTime previousMonthStart = currentMonthStart.AddMonths(-1);
+
+                var paymentsQuery = _studentPaymentRepository
+                    .Where(payment => payment.PaymentDate.HasValue && payment.Amount.HasValue);
+
+                decimal totalEarnings = await paymentsQuery
+                    .SumAsync(payment => (decimal?)(payment.Amount ?? 0)) ?? 0m;
+
+                decimal currentMonthEarnings = await paymentsQuery
+                    .Where(payment => payment.PaymentDate >= currentMonthStart && payment.PaymentDate < nextMonthStart)
+                    .SumAsync(payment => (decimal?)(payment.Amount ?? 0)) ?? 0m;
+
+                decimal previousMonthEarnings = await paymentsQuery
+                    .Where(payment => payment.PaymentDate >= previousMonthStart && payment.PaymentDate < currentMonthStart)
+                    .SumAsync(payment => (decimal?)(payment.Amount ?? 0)) ?? 0m;
+
+                double totalTeacherPayoutsDouble = await _teacherSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                double currentMonthTeacherPayoutsDouble = await _teacherSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue && salary.Month.HasValue &&
+                                     salary.Month.Value >= currentMonthStart && salary.Month.Value < nextMonthStart)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                double previousMonthTeacherPayoutsDouble = await _teacherSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue && salary.Month.HasValue &&
+                                     salary.Month.Value >= previousMonthStart && salary.Month.Value < currentMonthStart)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                double totalManagerPayoutsDouble = await _managerSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                double currentMonthManagerPayoutsDouble = await _managerSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue && salary.Month.HasValue &&
+                                     salary.Month.Value >= currentMonthStart && salary.Month.Value < nextMonthStart)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                double previousMonthManagerPayoutsDouble = await _managerSalaryRepository
+                    .Where(salary => salary.Sallary.HasValue && salary.Month.HasValue &&
+                                     salary.Month.Value >= previousMonthStart && salary.Month.Value < currentMonthStart)
+                    .SumAsync(salary => salary.Sallary ?? 0d);
+
+                decimal totalTeacherPayouts = Round(Convert.ToDecimal(totalTeacherPayoutsDouble));
+                decimal currentMonthTeacherPayouts = Round(Convert.ToDecimal(currentMonthTeacherPayoutsDouble));
+                decimal previousMonthTeacherPayouts = Round(Convert.ToDecimal(previousMonthTeacherPayoutsDouble));
+
+                decimal totalManagerPayouts = Round(Convert.ToDecimal(totalManagerPayoutsDouble));
+                decimal currentMonthManagerPayouts = Round(Convert.ToDecimal(currentMonthManagerPayoutsDouble));
+                decimal previousMonthManagerPayouts = Round(Convert.ToDecimal(previousMonthManagerPayoutsDouble));
+
+                decimal currentMonthNetIncome = Round(currentMonthEarnings - currentMonthTeacherPayouts - currentMonthManagerPayouts);
+                decimal previousMonthNetIncome = Round(previousMonthEarnings - previousMonthTeacherPayouts - previousMonthManagerPayouts);
+                decimal lifetimeNetIncome = Round(totalEarnings - totalTeacherPayouts - totalManagerPayouts);
+
+                int totalStudents = await _studentRepository.GetAll().CountAsync();
+                int totalTeachers = await _teacherRepository.GetAll().CountAsync();
+                int totalCircleReports = await _circleReportRepository.GetAll().CountAsync();
+
+                int currentMonthNewStudents = await _studentRepository
+                    .Where(student => student.CreatedAt.HasValue &&
+                                       student.CreatedAt.Value >= currentMonthStart && student.CreatedAt.Value < nextMonthStart)
+                    .CountAsync();
+
+                int previousMonthNewStudents = await _studentRepository
+                    .Where(student => student.CreatedAt.HasValue &&
+                                       student.CreatedAt.Value >= previousMonthStart && student.CreatedAt.Value < currentMonthStart)
+                    .CountAsync();
+
+                int currentMonthCircleReports = await _circleReportRepository
+                    .Where(report => report.CreationTime >= currentMonthStart && report.CreationTime < nextMonthStart)
+                    .CountAsync();
+
+                int previousMonthCircleReports = await _circleReportRepository
+                    .Where(report => report.CreationTime >= previousMonthStart && report.CreationTime < currentMonthStart)
+                    .CountAsync();
+
+                var summary = new DashboardSummaryDto
+                {
+                    PeriodStart = currentMonthStart,
+                    PeriodEnd = nextMonthStart,
+                    LifetimeEarnings = Round(totalEarnings),
+                    LifetimeTeacherPayouts = totalTeacherPayouts,
+                    LifetimeManagerPayouts = totalManagerPayouts,
+                    LifetimeNetIncome = lifetimeNetIncome,
+                    TotalStudents = totalStudents,
+                    TotalTeachers = totalTeachers,
+                    TotalCircleReports = totalCircleReports,
+                    Metrics = new List<DashboardMetricDto>
+                    {
+                        new DashboardMetricDto
+                        {
+                            Key = "earnings",
+                            Title = "Total Earnings",
+                            ValueType = "currency",
+                            Value = Round(currentMonthEarnings),
+                            PreviousValue = Round(previousMonthEarnings),
+                            ChangePercentage = CalculatePercentageChange(currentMonthEarnings, previousMonthEarnings),
+                            TotalValue = Round(totalEarnings)
+                        },
+                        new DashboardMetricDto
+                        {
+                            Key = "newStudents",
+                            Title = "New Students",
+                            ValueType = "count",
+                            Value = currentMonthNewStudents,
+                            PreviousValue = previousMonthNewStudents,
+                            ChangePercentage = CalculatePercentageChange(currentMonthNewStudents, previousMonthNewStudents),
+                            TotalValue = totalStudents
+                        },
+                        new DashboardMetricDto
+                        {
+                            Key = "circleReports",
+                            Title = "Circle Reports",
+                            ValueType = "count",
+                            Value = currentMonthCircleReports,
+                            PreviousValue = previousMonthCircleReports,
+                            ChangePercentage = CalculatePercentageChange(currentMonthCircleReports, previousMonthCircleReports),
+                            TotalValue = totalCircleReports
+                        },
+                        new DashboardMetricDto
+                        {
+                            Key = "netIncome",
+                            Title = "Net Income",
+                            ValueType = "currency",
+                            Value = currentMonthNetIncome,
+                            PreviousValue = previousMonthNetIncome,
+                            ChangePercentage = CalculatePercentageChange(currentMonthNetIncome, previousMonthNetIncome),
+                            TotalValue = lifetimeNetIncome
+                        }
+                    }
+                };
+
+                return output.CreateResponse(summary);
+            }
+            catch (Exception ex)
+            {
+                return output.CreateResponse(ex);
+            }
+        }
+
+        public async Task<IResponse<RepeatCustomerRateDto>> GetRepeatCustomerRateAsync(int months = 6)
+        {
+            Response<RepeatCustomerRateDto> output = new();
+            if (months <= 0)
+            {
+                months = 6;
+            }
+
+            try
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                DateTime currentMonthStart = new DateTime(utcNow.Year, utcNow.Month, 1);
+                DateTime startPeriod = currentMonthStart.AddMonths(1 - months);
+                DateTime endPeriod = currentMonthStart.AddMonths(1);
+
+                var allPayments = await _studentPaymentRepository
+                    .Where(payment => payment.PaymentDate.HasValue && payment.StudentId.HasValue)
+                    .Where(payment => payment.PaymentDate.Value < endPeriod)
+                    .Select(payment => new
+                    {
+                        StudentId = payment.StudentId!.Value,
+                        PaymentDate = payment.PaymentDate!.Value
+                    })
+                    .ToListAsync();
+
+                var firstPaymentByStudent = allPayments
+                    .GroupBy(payment => payment.StudentId)
+                    .ToDictionary(group => group.Key, group => group.Min(entry => entry.PaymentDate));
+
+                List<string> categories = new();
+                List<decimal> rateSeries = new();
+
+                for (int index = 0; index < months; index++)
+                {
+                    DateTime monthStart = new DateTime(startPeriod.Year, startPeriod.Month, 1).AddMonths(index);
+                    DateTime nextMonthStart = monthStart.AddMonths(1);
+
+                    categories.Add(monthStart.ToString("MMM yyyy", CultureInfo.InvariantCulture));
+
+                    var monthPayments = allPayments
+                        .Where(payment => payment.PaymentDate >= monthStart && payment.PaymentDate < nextMonthStart)
+                        .ToList();
+
+                    if (monthPayments.Count == 0)
+                    {
+                        rateSeries.Add(0m);
+                        continue;
+                    }
+
+                    int totalCustomers = monthPayments
+                        .Select(payment => payment.StudentId)
+                        .Distinct()
+                        .Count();
+
+                    if (totalCustomers == 0)
+                    {
+                        rateSeries.Add(0m);
+                        continue;
+                    }
+
+                    int returningCustomers = monthPayments
+                        .Select(payment => payment.StudentId)
+                        .Distinct()
+                        .Count(studentId => firstPaymentByStudent.TryGetValue(studentId, out DateTime firstPaymentDate) && firstPaymentDate < monthStart);
+
+                    decimal returningRate = totalCustomers == 0
+                        ? 0m
+                        : Math.Round((decimal)returningCustomers / totalCustomers * 100m, 2, MidpointRounding.AwayFromZero);
+
+                    rateSeries.Add(returningRate);
+                }
+
+                decimal currentRate = rateSeries.LastOrDefault();
+                decimal previousRate = rateSeries.Count > 1 ? rateSeries[^2] : 0m;
+
+                RepeatCustomerRateDto dto = new()
+                {
+                    Chart = new ChartDto
+                    {
+                        Categories = categories,
+                        Series = new List<ChartSeriesDto>
+                        {
+                            new ChartSeriesDto
+                            {
+                                Name = "Returning Customers %",
+                                Data = rateSeries
+                            }
+                        }
+                    },
+                    CurrentRate = currentRate,
+                    PreviousRate = previousRate,
+                    RateChange = CalculatePercentageChange(currentRate, previousRate)
+                };
+
+                return output.CreateResponse(dto);
+            }
+            catch (Exception ex)
+            {
+                return output.CreateResponse(ex);
+            }
+        }
+
+        public async Task<IResponse<MonthlyRevenueChartDto>> GetMonthlyRevenueAsync(int months = 6)
+        {
+            Response<MonthlyRevenueChartDto> output = new();
+            if (months <= 0)
+            {
+                months = 6;
+            }
+
+            try
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                DateTime currentMonthStart = new DateTime(utcNow.Year, utcNow.Month, 1);
+                DateTime startPeriod = currentMonthStart.AddMonths(1 - months);
+                DateTime endPeriod = currentMonthStart.AddMonths(1);
+
+                var revenueData = await _studentPaymentRepository
+                    .Where(payment => payment.PaymentDate.HasValue && payment.Amount.HasValue &&
+                                       payment.PaymentDate.Value >= startPeriod && payment.PaymentDate.Value < endPeriod)
+                    .GroupBy(payment => new { payment.PaymentDate!.Value.Year, payment.PaymentDate!.Value.Month })
+                    .Select(group => new
+                    {
+                        group.Key.Year,
+                        group.Key.Month,
+                        Total = group.Sum(payment => (decimal?)(payment.Amount ?? 0)) ?? 0m
+                    })
+                    .ToListAsync();
+
+                var teacherData = await _teacherSalaryRepository
+                    .Where(salary => salary.Month.HasValue && salary.Month.Value >= startPeriod && salary.Month.Value < endPeriod)
+                    .GroupBy(salary => new { salary.Month!.Value.Year, salary.Month!.Value.Month })
+                    .Select(group => new
+                    {
+                        group.Key.Year,
+                        group.Key.Month,
+                        Total = group.Sum(salary => salary.Sallary ?? 0d)
+                    })
+                    .ToListAsync();
+
+                var managerData = await _managerSalaryRepository
+                    .Where(salary => salary.Month.HasValue && salary.Month.Value >= startPeriod && salary.Month.Value < endPeriod)
+                    .GroupBy(salary => new { salary.Month!.Value.Year, salary.Month!.Value.Month })
+                    .Select(group => new
+                    {
+                        group.Key.Year,
+                        group.Key.Month,
+                        Total = group.Sum(salary => salary.Sallary ?? 0d)
+                    })
+                    .ToListAsync();
+
+                List<string> categories = new();
+                List<decimal> revenueSeries = new();
+                List<decimal> teacherSeries = new();
+                List<decimal> managerSeries = new();
+                List<decimal> netSeries = new();
+
+                decimal totalRevenue = 0m;
+                decimal totalTeacher = 0m;
+                decimal totalManager = 0m;
+
+                for (int index = 0; index < months; index++)
+                {
+                    DateTime monthStart = new DateTime(startPeriod.Year, startPeriod.Month, 1).AddMonths(index);
+                    string monthLabel = monthStart.ToString("MMM yyyy", CultureInfo.InvariantCulture);
+                    categories.Add(monthLabel);
+
+                    decimal monthRevenue = revenueData
+                        .Where(entry => entry.Year == monthStart.Year && entry.Month == monthStart.Month)
+                        .Select(entry => entry.Total)
+                        .FirstOrDefault();
+
+                    decimal monthTeacher = teacherData
+                        .Where(entry => entry.Year == monthStart.Year && entry.Month == monthStart.Month)
+                        .Select(entry => Convert.ToDecimal(entry.Total))
+                        .FirstOrDefault();
+
+                    decimal monthManager = managerData
+                        .Where(entry => entry.Year == monthStart.Year && entry.Month == monthStart.Month)
+                        .Select(entry => Convert.ToDecimal(entry.Total))
+                        .FirstOrDefault();
+
+                    decimal monthNet = monthRevenue - monthTeacher - monthManager;
+
+                    totalRevenue += monthRevenue;
+                    totalTeacher += monthTeacher;
+                    totalManager += monthManager;
+
+                    revenueSeries.Add(Round(monthRevenue));
+                    teacherSeries.Add(Round(monthTeacher));
+                    managerSeries.Add(Round(monthManager));
+                    netSeries.Add(Round(monthNet));
+                }
+
+                MonthlyRevenueChartDto dto = new()
+                {
+                    Chart = new ChartDto
+                    {
+                        Categories = categories,
+                        Series = new List<ChartSeriesDto>
+                        {
+                            new ChartSeriesDto { Name = "Revenue", Data = revenueSeries },
+                            new ChartSeriesDto { Name = "Teacher Salaries", Data = teacherSeries },
+                            new ChartSeriesDto { Name = "Manager Salaries", Data = managerSeries },
+                            new ChartSeriesDto { Name = "Net Income", Data = netSeries }
+                        }
+                    },
+                    TotalRevenue = Round(totalRevenue),
+                    TotalTeacherPayout = Round(totalTeacher),
+                    TotalManagerPayout = Round(totalManager),
+                    TotalNetIncome = Round(totalRevenue - totalTeacher - totalManager)
+                };
+
+                return output.CreateResponse(dto);
+            }
+            catch (Exception ex)
+            {
+                return output.CreateResponse(ex);
+            }
+        }
+
+        public async Task<IResponse<PieChartDto>> GetRevenueByCurrencyAsync(DateTime? startDate = null, DateTime? endDate = null)
+        {
+            Response<PieChartDto> output = new();
+            try
+            {
+                var paymentsQuery = _studentPaymentRepository
+                    .Where(payment => payment.Amount.HasValue && payment.PaymentDate.HasValue && payment.CurrencyId.HasValue);
+
+                if (startDate.HasValue)
+                {
+                    paymentsQuery = paymentsQuery.Where(payment => payment.PaymentDate >= startDate.Value);
+                }
+
+                if (endDate.HasValue)
+                {
+                    paymentsQuery = paymentsQuery.Where(payment => payment.PaymentDate < endDate.Value);
+                }
+
+                var groupedPayments = await paymentsQuery
+                    .GroupBy(payment => payment.CurrencyId!.Value)
+                    .Select(group => new
+                    {
+                        CurrencyId = group.Key,
+                        Total = group.Sum(payment => (decimal?)(payment.Amount ?? 0)) ?? 0m
+                    })
+                    .ToListAsync();
+
+                decimal totalValue = groupedPayments.Sum(entry => entry.Total);
+
+                List<PieChartSliceDto> slices = groupedPayments
+                    .Select(entry =>
+                    {
+                        string label = CurrencyLabels.TryGetValue(entry.CurrencyId, out string? mappedLabel)
+                            ? mappedLabel
+                            : $"Currency {entry.CurrencyId}";
+
+                        decimal percentage = totalValue == 0m
+                            ? 0m
+                            : Math.Round(entry.Total / totalValue * 100m, 2, MidpointRounding.AwayFromZero);
+
+                        return new PieChartSliceDto
+                        {
+                            Label = label,
+                            Value = Round(entry.Total),
+                            Percentage = percentage
+                        };
+                    })
+                    .ToList();
+
+                PieChartDto dto = new()
+                {
+                    Slices = slices,
+                    TotalValue = Round(totalValue)
+                };
+
+                return output.CreateResponse(dto);
+            }
+            catch (Exception ex)
+            {
+                return output.CreateResponse(ex);
+            }
+        }
+
+        private static decimal CalculatePercentageChange(decimal current, decimal previous)
+        {
+            if (previous == 0m)
+            {
+                return current == 0m ? 0m : 100m;
+            }
+
+            decimal difference = current - previous;
+            return Math.Round(difference / Math.Abs(previous) * 100m, 2, MidpointRounding.AwayFromZero);
+        }
+
+        private static decimal Round(decimal value)
+        {
+            return Math.Round(value, 2, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/OrbitsGeneralProject.BLL/DashboardService/IDashboardBLL.cs
+++ b/OrbitsGeneralProject.BLL/DashboardService/IDashboardBLL.cs
@@ -1,0 +1,13 @@
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.DTO.Dashboard;
+
+namespace Orbits.GeneralProject.BLL.DashboardService
+{
+    public interface IDashboardBLL
+    {
+        Task<IResponse<DashboardSummaryDto>> GetSummaryAsync();
+        Task<IResponse<RepeatCustomerRateDto>> GetRepeatCustomerRateAsync(int months = 6);
+        Task<IResponse<MonthlyRevenueChartDto>> GetMonthlyRevenueAsync(int months = 6);
+        Task<IResponse<PieChartDto>> GetRevenueByCurrencyAsync(DateTime? startDate = null, DateTime? endDate = null);
+    }
+}

--- a/OrbitsGeneralProject.DTO/Dashboard/ChartDtos.cs
+++ b/OrbitsGeneralProject.DTO/Dashboard/ChartDtos.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.Dashboard
+{
+    public class ChartDto
+    {
+        public List<string> Categories { get; set; } = new();
+        public List<ChartSeriesDto> Series { get; set; } = new();
+    }
+
+    public class ChartSeriesDto
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<decimal> Data { get; set; } = new();
+    }
+
+    public class PieChartDto
+    {
+        public List<PieChartSliceDto> Slices { get; set; } = new();
+        public decimal TotalValue { get; set; }
+    }
+
+    public class PieChartSliceDto
+    {
+        public string Label { get; set; } = string.Empty;
+        public decimal Value { get; set; }
+        public decimal Percentage { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/Dashboard/DashboardSummaryDto.cs
+++ b/OrbitsGeneralProject.DTO/Dashboard/DashboardSummaryDto.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.Dashboard
+{
+    public class DashboardSummaryDto
+    {
+        public DateTime PeriodStart { get; set; }
+        public DateTime PeriodEnd { get; set; }
+        public List<DashboardMetricDto> Metrics { get; set; } = new();
+        public decimal LifetimeEarnings { get; set; }
+        public decimal LifetimeTeacherPayouts { get; set; }
+        public decimal LifetimeManagerPayouts { get; set; }
+        public decimal LifetimeNetIncome { get; set; }
+        public int TotalStudents { get; set; }
+        public int TotalTeachers { get; set; }
+        public int TotalCircleReports { get; set; }
+    }
+
+    public class DashboardMetricDto
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string ValueType { get; set; } = string.Empty;
+        public decimal Value { get; set; }
+        public decimal PreviousValue { get; set; }
+        public decimal ChangePercentage { get; set; }
+        public decimal? TotalValue { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/Dashboard/MonthlyRevenueChartDto.cs
+++ b/OrbitsGeneralProject.DTO/Dashboard/MonthlyRevenueChartDto.cs
@@ -1,0 +1,11 @@
+namespace Orbits.GeneralProject.DTO.Dashboard
+{
+    public class MonthlyRevenueChartDto
+    {
+        public ChartDto Chart { get; set; } = new();
+        public decimal TotalRevenue { get; set; }
+        public decimal TotalTeacherPayout { get; set; }
+        public decimal TotalManagerPayout { get; set; }
+        public decimal TotalNetIncome { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/Dashboard/RepeatCustomerRateDto.cs
+++ b/OrbitsGeneralProject.DTO/Dashboard/RepeatCustomerRateDto.cs
@@ -1,0 +1,10 @@
+namespace Orbits.GeneralProject.DTO.Dashboard
+{
+    public class RepeatCustomerRateDto
+    {
+        public ChartDto Chart { get; set; } = new();
+        public decimal CurrentRate { get; set; }
+        public decimal PreviousRate { get; set; }
+        public decimal RateChange { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable dashboard DTOs for summary cards, charts, and pie visualizations
- implement DashboardBLL to aggregate revenue, subscription, and retention metrics
- expose DashboardController endpoints that surface summary, repeat-customer, monthly revenue, and currency breakdown data for the Angular charts

## Testing
- dotnet build Orbits.GeneralProject.sln *(fails: dotnet CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca89e79a10832280360797a4a5182a