### PR TITLE
Add subscribe type analytics endpoint

### DIFF
--- a/OrbitsCameraProject.API/Controllers/SubscribeController.cs
+++ b/OrbitsCameraProject.API/Controllers/SubscribeController.cs
@@ -23,6 +23,9 @@ namespace OrbitsProject.API.Controllers
         [HttpGet("GetTypeResultsByFilter"), ProducesResponseType(typeof(IResponse<PagedResultDto<SubscribeTypeReDto>>), 200)]
         public IActionResult GetTypeResultsByFilter([FromQuery] FilteredResultRequestDto paginationFilterModel) => Ok(_SubscribeBLL.GetTypeResultsByFilter(paginationFilterModel));
 
+        [HttpGet("TypeStatistics"), ProducesResponseType(typeof(IResponse<SubscribeTypeStatisticsDto>), 200)]
+        public async Task<IActionResult> GetTypeStatistics() => Ok(await _SubscribeBLL.GetTypeStatisticsAsync());
+
         [HttpPost("CreateSubscribe"), ProducesResponseType(typeof(IResponse<bool>), 200)]
         public async Task<IActionResult> CreateSubscribe(CreateSubscribeDto model) => Ok(await _SubscribeBLL.AddAsync(model, UserId));
         [HttpPost("CreateSubscribeType"), ProducesResponseType(typeof(IResponse<bool>), 200)]

--- a/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
+++ b/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
@@ -15,6 +15,7 @@ namespace Orbits.GeneralProject.BLL.SubscribeService
         Task<IResponse<bool>> AddSubscribeTypeAsync(CreateSubscribeTypeDto model, int userId);
         IResponse<PagedResultDto<SubscribeReDto>> GetPagedList(FilteredResultRequestDto pagedDto);
         IResponse<PagedResultDto<SubscribeTypeReDto>> GetTypeResultsByFilter(FilteredResultRequestDto pagedDto);
+        Task<IResponse<SubscribeTypeStatisticsDto>> GetTypeStatisticsAsync();
         Task<IResponse<bool>> Delete(int id);
         Task<IResponse<bool>> DeleteType(int id);
         //Task<IResponse<SubscribeDto>> GetSubscribeById(int id);

--- a/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
+++ b/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.SubscribeDtos
+{
+    public class SubscribeTypeStatisticsDto
+    {
+        public List<string> Labels { get; set; } = new();
+
+        public List<int> Series { get; set; } = new();
+
+        public List<SubscribeTypeStatisticItemDto> Items { get; set; } = new();
+
+        public int TotalSubscriptions { get; set; }
+
+        public int UniqueSubscribers { get; set; }
+    }
+
+    public class SubscribeTypeStatisticItemDto
+    {
+        public int? SubscribeTypeId { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public int SubscriptionCount { get; set; }
+
+        public int UniqueStudentCount { get; set; }
+
+        public decimal Percentage { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SubscribeController endpoint to expose subscribe type statistics for the overview chart
- implement BLL aggregation that counts student subscriptions per type and returns structured chart data
- introduce DTOs describing subscribe type statistics and percentages for frontend consumption

## Testing
- `dotnet build Orbits.GeneralProject.sln` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab7d84b14832295ff1bc023a482b9