### PR TITLE
Return structured subscribe type statistics for dashboard

### DIFF
--- a/OrbitsCameraProject.API/Controllers/SubscribeController.cs
+++ b/OrbitsCameraProject.API/Controllers/SubscribeController.cs
@@ -23,6 +23,9 @@ namespace OrbitsProject.API.Controllers
         [HttpGet("GetTypeResultsByFilter"), ProducesResponseType(typeof(IResponse<PagedResultDto<SubscribeTypeReDto>>), 200)]
         public IActionResult GetTypeResultsByFilter([FromQuery] FilteredResultRequestDto paginationFilterModel) => Ok(_SubscribeBLL.GetTypeResultsByFilter(paginationFilterModel));
 
+        [HttpGet("TypeStatistics"), ProducesResponseType(typeof(IResponse<SubscribeTypeStatisticsDto>), 200)]
+        public async Task<IActionResult> GetTypeStatistics() => Ok(await _SubscribeBLL.GetTypeStatisticsAsync());
+
         [HttpPost("CreateSubscribe"), ProducesResponseType(typeof(IResponse<bool>), 200)]
         public async Task<IActionResult> CreateSubscribe(CreateSubscribeDto model) => Ok(await _SubscribeBLL.AddAsync(model, UserId));
         [HttpPost("CreateSubscribeType"), ProducesResponseType(typeof(IResponse<bool>), 200)]

--- a/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
+++ b/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
@@ -15,6 +15,7 @@ namespace Orbits.GeneralProject.BLL.SubscribeService
         Task<IResponse<bool>> AddSubscribeTypeAsync(CreateSubscribeTypeDto model, int userId);
         IResponse<PagedResultDto<SubscribeReDto>> GetPagedList(FilteredResultRequestDto pagedDto);
         IResponse<PagedResultDto<SubscribeTypeReDto>> GetTypeResultsByFilter(FilteredResultRequestDto pagedDto);
+        Task<IResponse<SubscribeTypeStatisticsDto>> GetTypeStatisticsAsync();
         Task<IResponse<bool>> Delete(int id);
         Task<IResponse<bool>> DeleteType(int id);
         //Task<IResponse<SubscribeDto>> GetSubscribeById(int id);

--- a/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
+++ b/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.SubscribeDtos
+{
+    public class SubscribeTypeStatisticsDto
+    {
+        public SubscribeTypeDistributionDto Distribution { get; set; } = new();
+
+        public List<SubscribeTypeBreakdownItemDto> Breakdown { get; set; } = new();
+
+        public int TotalSubscribers { get; set; }
+
+        public int UniqueSubscribers { get; set; }
+
+        public int TotalSubscriptionTypes { get; set; }
+    }
+
+    public class SubscribeTypeDistributionDto
+    {
+        public int TotalValue { get; set; }
+
+        public List<SubscribeTypeDistributionSliceDto> Slices { get; set; } = new();
+    }
+
+    public class SubscribeTypeDistributionSliceDto
+    {
+        public string Label { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+
+        public decimal Percentage { get; set; }
+    }
+
+    public class SubscribeTypeBreakdownItemDto
+    {
+        public int SubscribeTypeId { get; set; }
+
+        public string TypeName { get; set; } = string.Empty;
+
+        public int SubscriberCount { get; set; }
+
+        public decimal Percentage { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- reshape the subscribe type statistics DTO to expose distribution slices, breakdown rows, and aggregate totals expected by the dashboard chart
- recompute the statistics in the subscribe service to populate the new structure with subscriber counts, percentages, and unique subscriber totals

## Testing
- `dotnet build Orbits.GeneralProject.sln` *(fails: `dotnet` CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab7d84b14832295ff1bc023a482b9