### PR TITLE
Avoid filtering student subscriptions on unmapped IsDeleted

### DIFF
--- a/OrbitsCameraProject.API/Controllers/SubscribeController.cs
+++ b/OrbitsCameraProject.API/Controllers/SubscribeController.cs
@@ -23,6 +23,9 @@ namespace OrbitsProject.API.Controllers
         [HttpGet("GetTypeResultsByFilter"), ProducesResponseType(typeof(IResponse<PagedResultDto<SubscribeTypeReDto>>), 200)]
         public IActionResult GetTypeResultsByFilter([FromQuery] FilteredResultRequestDto paginationFilterModel) => Ok(_SubscribeBLL.GetTypeResultsByFilter(paginationFilterModel));
 
+        [HttpGet("TypeStatistics"), ProducesResponseType(typeof(IResponse<SubscribeTypeStatisticsDto>), 200)]
+        public async Task<IActionResult> GetTypeStatistics() => Ok(await _SubscribeBLL.GetTypeStatisticsAsync());
+
         [HttpPost("CreateSubscribe"), ProducesResponseType(typeof(IResponse<bool>), 200)]
         public async Task<IActionResult> CreateSubscribe(CreateSubscribeDto model) => Ok(await _SubscribeBLL.AddAsync(model, UserId));
         [HttpPost("CreateSubscribeType"), ProducesResponseType(typeof(IResponse<bool>), 200)]

--- a/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
+++ b/OrbitsGeneralProject.BLL/SubscribeService/ISubscribeBLL.cs
@@ -15,6 +15,7 @@ namespace Orbits.GeneralProject.BLL.SubscribeService
         Task<IResponse<bool>> AddSubscribeTypeAsync(CreateSubscribeTypeDto model, int userId);
         IResponse<PagedResultDto<SubscribeReDto>> GetPagedList(FilteredResultRequestDto pagedDto);
         IResponse<PagedResultDto<SubscribeTypeReDto>> GetTypeResultsByFilter(FilteredResultRequestDto pagedDto);
+        Task<IResponse<SubscribeTypeStatisticsDto>> GetTypeStatisticsAsync();
         Task<IResponse<bool>> Delete(int id);
         Task<IResponse<bool>> DeleteType(int id);
         //Task<IResponse<SubscribeDto>> GetSubscribeById(int id);

--- a/OrbitsGeneralProject.BLL/SubscribeService/SubscribeBLL.cs
+++ b/OrbitsGeneralProject.BLL/SubscribeService/SubscribeBLL.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using FluentValidation.Results;
+using Microsoft.EntityFrameworkCore;
 using Orbits.GeneralProject.BLL.BaseReponse;
 using Orbits.GeneralProject.BLL.Constants;
 using Orbits.GeneralProject.Core.Entities;
@@ -20,13 +21,15 @@ namespace Orbits.GeneralProject.BLL.SubscribeService
         private readonly IMapper _mapper;
         private readonly IRepository<Subscribe> _SubscribeRepository;
         private readonly IRepository<SubscribeType> _SubscribeTypeRepository;
+        private readonly IRepository<StudentSubscribe> _StudentSubscribeRepository;
         private readonly IUnitOfWork _unitOfWork;
-        public SubscribeBLL(IMapper mapper, IRepository<Subscribe> SubscribeRepository, IUnitOfWork unitOfWork, IRepository<SubscribeType> subscribeTypeRepository) : base(mapper)
+        public SubscribeBLL(IMapper mapper, IRepository<Subscribe> SubscribeRepository, IUnitOfWork unitOfWork, IRepository<SubscribeType> subscribeTypeRepository, IRepository<StudentSubscribe> studentSubscribeRepository) : base(mapper)
         {
             _mapper = mapper;
             _SubscribeRepository = SubscribeRepository;
             _unitOfWork = unitOfWork;
             _SubscribeTypeRepository = subscribeTypeRepository;
+            _StudentSubscribeRepository = studentSubscribeRepository;
         }
         public IResponse<PagedResultDto<SubscribeReDto>> GetPagedList(FilteredResultRequestDto pagedDto)
         {
@@ -49,6 +52,122 @@ namespace Orbits.GeneralProject.BLL.SubscribeService
               disableFilter: true,
               excluededColumns: null);
             return output.CreateResponse(list);
+        }
+
+        public async Task<IResponse<SubscribeTypeStatisticsDto>> GetTypeStatisticsAsync()
+        {
+            Response<SubscribeTypeStatisticsDto> output = new();
+
+            try
+            {
+                var subscribeTypes = await _SubscribeTypeRepository
+                    .GetAll(true)
+                    .AsNoTracking()
+                    .Where(type => type.IsDeleted != true)
+                    .Select(type => new
+                    {
+                        type.Id,
+                        Name = (type.Name ?? string.Empty).Trim()
+                    })
+                    .ToListAsync();
+
+                var activeTypeIds = subscribeTypes
+                    .Select(type => type.Id)
+                    .ToHashSet();
+
+                var studentSubscriptions = await _StudentSubscribeRepository
+                    .GetAll(true)
+                    .AsNoTracking()
+                    .Where(subscription => subscription.StudentSubscribeTypeId.HasValue)
+                    .Select(subscription => new
+                    {
+                        TypeId = subscription.StudentSubscribeTypeId!.Value,
+                        subscription.StudentId
+                    })
+                    .ToListAsync();
+
+                var filteredSubscriptions = studentSubscriptions
+                    .Where(subscription => activeTypeIds.Contains(subscription.TypeId))
+                    .ToList();
+
+                var groupedSubscriptions = filteredSubscriptions
+                    .GroupBy(subscription => subscription.TypeId)
+                    .ToDictionary(
+                        group => group.Key,
+                        group => new
+                        {
+                            SubscriptionCount = group.Count(),
+                            UniqueStudentCount = group
+                                .Select(subscription => subscription.StudentId)
+                                .Where(studentId => studentId.HasValue)
+                                .Select(studentId => studentId!.Value)
+                                .Distinct()
+                                .Count()
+                        });
+
+                int totalSubscriptions = groupedSubscriptions
+                    .Values
+                    .Sum(group => group.SubscriptionCount);
+
+                int totalUniqueSubscribers = filteredSubscriptions
+                    .Select(subscription => subscription.StudentId)
+                    .Where(studentId => studentId.HasValue)
+                    .Select(studentId => studentId!.Value)
+                    .Distinct()
+                    .Count();
+
+                decimal CalculatePercentage(int value, int total) => total == 0
+                    ? 0m
+                    : Math.Round((decimal)value / total * 100m, 2, MidpointRounding.AwayFromZero);
+
+                var breakdown = subscribeTypes
+                    .Select(type =>
+                    {
+                        groupedSubscriptions.TryGetValue(type.Id, out var counts);
+
+                        int subscriberCount = counts?.SubscriptionCount ?? 0;
+                        string displayName = string.IsNullOrWhiteSpace(type.Name) ? "غير محدد" : type.Name;
+
+                        return new SubscribeTypeBreakdownItemDto
+                        {
+                            SubscribeTypeId = type.Id,
+                            TypeName = displayName,
+                            SubscriberCount = subscriberCount,
+                            Percentage = CalculatePercentage(subscriberCount, totalSubscriptions)
+                        };
+                    })
+                    .OrderByDescending(item => item.SubscriberCount)
+                    .ThenBy(item => item.TypeName)
+                    .ToList();
+
+                SubscribeTypeDistributionDto distribution = new()
+                {
+                    TotalValue = totalSubscriptions,
+                    Slices = breakdown
+                        .Select(item => new SubscribeTypeDistributionSliceDto
+                        {
+                            Label = item.TypeName,
+                            Value = item.SubscriberCount,
+                            Percentage = item.Percentage
+                        })
+                        .ToList()
+                };
+
+                SubscribeTypeStatisticsDto statistics = new()
+                {
+                    Distribution = distribution,
+                    Breakdown = breakdown,
+                    TotalSubscribers = totalSubscriptions,
+                    UniqueSubscribers = totalUniqueSubscribers,
+                    TotalSubscriptionTypes = subscribeTypes.Count
+                };
+
+                return output.CreateResponse(statistics);
+            }
+            catch (Exception ex)
+            {
+                return output.CreateResponse(ex);
+            }
         }
         public async Task<IResponse<bool>> AddAsync(CreateSubscribeDto model, int userId)
         {

--- a/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
+++ b/OrbitsGeneralProject.DTO/SubscribeDtos/SubscribeTypeStatisticsDto.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.SubscribeDtos
+{
+    public class SubscribeTypeStatisticsDto
+    {
+        public SubscribeTypeDistributionDto Distribution { get; set; } = new();
+
+        public List<SubscribeTypeBreakdownItemDto> Breakdown { get; set; } = new();
+
+        public int TotalSubscribers { get; set; }
+
+        public int UniqueSubscribers { get; set; }
+
+        public int TotalSubscriptionTypes { get; set; }
+    }
+
+    public class SubscribeTypeDistributionDto
+    {
+        public int TotalValue { get; set; }
+
+        public List<SubscribeTypeDistributionSliceDto> Slices { get; set; } = new();
+    }
+
+    public class SubscribeTypeDistributionSliceDto
+    {
+        public string Label { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+
+        public decimal Percentage { get; set; }
+    }
+
+    public class SubscribeTypeBreakdownItemDto
+    {
+        public int SubscribeTypeId { get; set; }
+
+        public string TypeName { get; set; } = string.Empty;
+
+        public int SubscriberCount { get; set; }
+
+        public decimal Percentage { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- drop the StudentSubscribe IsDeleted filter from the type statistics query so Entity Framework can translate the projection

## Testing
- `dotnet build Orbits.GeneralProject.sln` *(fails: `dotnet` CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab7d84b14832295ff1bc023a482b9