### PR TITLE
Add monthly teacher salary invoice generation service

### DIFF
--- a/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.BLL.TeacherSallaryService;
+using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
+
+namespace OrbitsProject.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class TeacherSallaryController : AppBaseController
+    {
+        private readonly ITeacherSallaryBLL _teacherSallaryBll;
+
+        public TeacherSallaryController(ITeacherSallaryBLL teacherSallaryBll)
+        {
+            _teacherSallaryBll = teacherSallaryBll;
+        }
+
+        /// <summary>
+        /// Generates teacher salary invoices for the specified month. If no month is provided
+        /// the previous calendar month is used.
+        /// </summary>
+        /// <param name="month">Optional month (the day component is ignored).</param>
+        [HttpPost("GenerateMonthly")]
+        [ProducesResponseType(typeof(IResponse<TeacherSallaryGenerationResultDto>), 200)]
+        public async Task<IActionResult> GenerateMonthly([FromQuery] DateTime? month = null)
+        {
+            var result = await _teacherSallaryBll.GenerateMonthlyInvoicesAsync(month, UserId);
+            return Ok(result);
+        }
+    }
+}

--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
@@ -1,0 +1,17 @@
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
+
+namespace Orbits.GeneralProject.BLL.TeacherSallaryService
+{
+    public interface ITeacherSallaryBLL
+    {
+        /// <summary>
+        /// Generates (or refreshes) teacher salary invoices for the specified month.
+        /// If no month is provided the previous calendar month is used.
+        /// </summary>
+        /// <param name="month">The month to generate invoices for. The day component is ignored.</param>
+        /// <param name="createdBy">Optional user id used for audit fields.</param>
+        /// <returns>A response describing how many invoices were created/updated.</returns>
+        Task<IResponse<TeacherSallaryGenerationResultDto>> GenerateMonthlyInvoicesAsync(DateTime? month = null, int? createdBy = null);
+    }
+}

--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/TeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/TeacherSallaryBLL.cs
@@ -1,0 +1,170 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.Core.Entities;
+using Orbits.GeneralProject.Core.Infrastructure;
+using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
+using Orbits.GeneralProject.Repositroy.Base;
+
+namespace Orbits.GeneralProject.BLL.TeacherSallaryService
+{
+    public class TeacherSallaryBLL : BaseBLL, ITeacherSallaryBLL
+    {
+        private readonly IRepository<TeacherReportRecord> _teacherReportRepository;
+        private readonly IRepository<TeacherSallary> _teacherSallaryRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public TeacherSallaryBLL(
+            IMapper mapper,
+            IRepository<TeacherReportRecord> teacherReportRepository,
+            IRepository<TeacherSallary> teacherSallaryRepository,
+            IUnitOfWork unitOfWork) : base(mapper)
+        {
+            _teacherReportRepository = teacherReportRepository;
+            _teacherSallaryRepository = teacherSallaryRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<IResponse<TeacherSallaryGenerationResultDto>> GenerateMonthlyInvoicesAsync(DateTime? month = null, int? createdBy = null)
+        {
+            var response = new Response<TeacherSallaryGenerationResultDto>();
+
+            try
+            {
+                DateTime reference = month ?? DateTime.UtcNow;
+                DateTime monthStart = new(reference.Year, reference.Month, 1);
+
+                // When no explicit month is supplied we assume the job is running at the beginning
+                // of a new month and therefore should generate invoices for the previous month.
+                if (!month.HasValue)
+                {
+                    monthStart = monthStart.AddMonths(-1);
+                }
+
+                DateTime monthEnd = monthStart.AddMonths(1);
+
+                var groupedTeacherRecords = await _teacherReportRepository
+                    .Where(record =>
+                        record.TeacherId.HasValue &&
+                        record.CreatedAt.HasValue &&
+                        record.CreatedAt.Value >= monthStart &&
+                        record.CreatedAt.Value < monthEnd)
+                    .GroupBy(record => record.TeacherId!.Value)
+                    .Select(group => new
+                    {
+                        TeacherId = group.Key,
+                        TotalMinutes = group.Sum(r => r.Minutes ?? 0),
+                        TotalSalary = group.Sum(r => (double?)(r.CircleSallary ?? 0)) ?? 0d
+                    })
+                    .ToListAsync();
+
+                var result = new TeacherSallaryGenerationResultDto
+                {
+                    Month = monthStart
+                };
+
+                if (groupedTeacherRecords.Count == 0)
+                {
+                    return response.CreateResponse(result);
+                }
+
+                var existingInvoices = await _teacherSallaryRepository
+                    .Where(invoice =>
+                        invoice.TeacherId.HasValue &&
+                        invoice.Month.HasValue &&
+                        invoice.Month.Value.Year == monthStart.Year &&
+                        invoice.Month.Value.Month == monthStart.Month)
+                    .ToListAsync();
+
+                var existingByTeacher = new Dictionary<int, TeacherSallary>();
+                foreach (var invoice in existingInvoices)
+                {
+                    if (invoice.TeacherId.HasValue && !existingByTeacher.ContainsKey(invoice.TeacherId.Value))
+                    {
+                        existingByTeacher.Add(invoice.TeacherId.Value, invoice);
+                    }
+                }
+
+                var newInvoices = new List<TeacherSallary>();
+                bool hasChanges = false;
+
+                foreach (var group in groupedTeacherRecords)
+                {
+                    if (group.TotalMinutes <= 0)
+                    {
+                        result.SkippedZeroValueInvoices++;
+                        continue;
+                    }
+
+                    result.TotalTeachers++;
+                    result.TotalMinutes += group.TotalMinutes;
+                    var roundedAmount = Math.Round(group.TotalSalary, 2, MidpointRounding.AwayFromZero);
+                    result.TotalSalary += roundedAmount;
+
+                    if (existingByTeacher.TryGetValue(group.TeacherId, out var existingInvoice))
+                    {
+                        if (existingInvoice.IsPayed == true)
+                        {
+                            result.SkippedPaidInvoices++;
+                            continue;
+                        }
+
+                        bool shouldUpdate = false;
+
+                        if (!existingInvoice.Month.HasValue || existingInvoice.Month.Value.Date != monthStart.Date)
+                        {
+                            existingInvoice.Month = monthStart;
+                            shouldUpdate = true;
+                        }
+
+                        if (existingInvoice.Sallary == null || Math.Abs(existingInvoice.Sallary.Value - roundedAmount) > 0.01)
+                        {
+                            existingInvoice.Sallary = roundedAmount;
+                            shouldUpdate = true;
+                        }
+
+                        if (shouldUpdate)
+                        {
+                            existingInvoice.ModefiedAt = DateTime.UtcNow;
+                            existingInvoice.ModefiedBy = createdBy;
+                            result.UpdatedInvoices++;
+                            hasChanges = true;
+                        }
+                    }
+                    else
+                    {
+                        var invoice = new TeacherSallary
+                        {
+                            TeacherId = group.TeacherId,
+                            Month = monthStart,
+                            Sallary = roundedAmount,
+                            CreatedAt = DateTime.UtcNow,
+                            CreatedBy = createdBy,
+                            IsPayed = false
+                        };
+
+                        newInvoices.Add(invoice);
+                        result.CreatedInvoices++;
+                        hasChanges = true;
+                    }
+                }
+
+                if (newInvoices.Count > 0)
+                {
+                    _teacherSallaryRepository.Add(newInvoices);
+                }
+
+                if (hasChanges)
+                {
+                    await _unitOfWork.CommitAsync();
+                }
+
+                return response.CreateResponse(result);
+            }
+            catch (Exception ex)
+            {
+                return response.CreateResponse(ex);
+            }
+        }
+    }
+}

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSallaryGenerationResultDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSallaryGenerationResultDto.cs
@@ -1,0 +1,42 @@
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    public class TeacherSallaryGenerationResultDto
+    {
+        public DateTime Month { get; set; }
+
+        /// <summary>
+        /// Number of invoices that were newly created for the requested month.
+        /// </summary>
+        public int CreatedInvoices { get; set; }
+
+        /// <summary>
+        /// Number of existing invoices that were updated with the latest totals.
+        /// </summary>
+        public int UpdatedInvoices { get; set; }
+
+        /// <summary>
+        /// Number of invoices that were skipped because they are already marked as paid.
+        /// </summary>
+        public int SkippedPaidInvoices { get; set; }
+
+        /// <summary>
+        /// Number of teachers that had no billable minutes for the requested month.
+        /// </summary>
+        public int SkippedZeroValueInvoices { get; set; }
+
+        /// <summary>
+        /// Total number of teachers that had billable activity for the requested month (excluding the zero-minute skips).
+        /// </summary>
+        public int TotalTeachers { get; set; }
+
+        /// <summary>
+        /// Sum of all billable minutes for the requested month.
+        /// </summary>
+        public int TotalMinutes { get; set; }
+
+        /// <summary>
+        /// Sum of all salary amounts calculated for the requested month.
+        /// </summary>
+        public double TotalSalary { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO and BLL service that calculates monthly teacher salary invoices from TeacherReportRecord entries
- ensure the service updates existing unpaid invoices or creates new ones while tracking summary statistics
- expose a TeacherSallary controller endpoint to trigger the monthly generation logic

## Testing
- `dotnet test Orbits.GeneralProject.sln` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe93230988322a3768e7a931e592c