### PR TITLE
Add endpoints for teacher monthly summary and invoices

### DIFF
--- a/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
@@ -28,5 +28,31 @@ namespace OrbitsProject.API.Controllers
             var result = await _teacherSallaryBll.GenerateMonthlyInvoicesAsync(month, UserId);
             return Ok(result);
         }
+
+        /// <summary>
+        /// Returns a monthly summary for a teacher including attendance breakdown and salary totals.
+        /// </summary>
+        /// <param name="teacherId">Optional teacher identifier. Defaults to the authenticated user.</param>
+        /// <param name="month">Optional month (the day component is ignored).</param>
+        [HttpGet("MonthlySummary")]
+        [ProducesResponseType(typeof(IResponse<TeacherMonthlySummaryDto>), 200)]
+        public async Task<IActionResult> GetMonthlySummary([FromQuery] int? teacherId = null, [FromQuery] DateTime? month = null)
+        {
+            var targetTeacherId = teacherId ?? UserId;
+            var result = await _teacherSallaryBll.GetMonthlySummaryAsync(targetTeacherId, month);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Retrieves an individual teacher salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        [HttpGet("Invoice/{invoiceId:int}")]
+        [ProducesResponseType(typeof(IResponse<TeacherInvoiceDto>), 200)]
+        public async Task<IActionResult> GetInvoice(int invoiceId)
+        {
+            var result = await _teacherSallaryBll.GetInvoiceByIdAsync(invoiceId);
+            return Ok(result);
+        }
     }
 }

--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
@@ -1,3 +1,4 @@
+using System;
 using Orbits.GeneralProject.BLL.BaseReponse;
 using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
 
@@ -13,5 +14,18 @@ namespace Orbits.GeneralProject.BLL.TeacherSallaryService
         /// <param name="createdBy">Optional user id used for audit fields.</param>
         /// <returns>A response describing how many invoices were created/updated.</returns>
         Task<IResponse<TeacherSallaryGenerationResultDto>> GenerateMonthlyInvoicesAsync(DateTime? month = null, int? createdBy = null);
+
+        /// <summary>
+        /// Calculates a teacher's activity summary for a specific month including attendance breakdown and salary totals.
+        /// </summary>
+        /// <param name="teacherId">The teacher identifier.</param>
+        /// <param name="month">Optional month filter. When omitted the previous calendar month is used.</param>
+        Task<IResponse<TeacherMonthlySummaryDto>> GetMonthlySummaryAsync(int teacherId, DateTime? month = null);
+
+        /// <summary>
+        /// Retrieves a salary invoice by its identifier.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        Task<IResponse<TeacherInvoiceDto>> GetInvoiceByIdAsync(int invoiceId);
     }
 }

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherInvoiceDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherInvoiceDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    public class TeacherInvoiceDto
+    {
+        public int Id { get; set; }
+        public int? TeacherId { get; set; }
+        public string? TeacherName { get; set; }
+        public DateTime? Month { get; set; }
+        public double? Salary { get; set; }
+        public bool? IsPayed { get; set; }
+        public DateTime? PayedAt { get; set; }
+        public string? ReceiptPath { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public DateTime? ModefiedAt { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherMonthlySummaryDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherMonthlySummaryDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    public class TeacherMonthlySummaryDto
+    {
+        public int TeacherId { get; set; }
+        public string? TeacherName { get; set; }
+        public DateTime Month { get; set; }
+        public int TotalReports { get; set; }
+        public int TotalMinutes { get; set; }
+        public int PresentCount { get; set; }
+        public int AbsentWithExcuseCount { get; set; }
+        public int AbsentWithoutExcuseCount { get; set; }
+        public double TotalSalary { get; set; }
+        public TeacherInvoiceDto? Invoice { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs that describe teacher salary invoices and monthly summaries
- extend the teacher salary business logic with monthly aggregation and invoice lookup helpers
- expose API endpoints to fetch a teacher's monthly summary and retrieve invoice details by id

## Testing
- `dotnet test` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbedbe57a883229612ece40ffd2c07