### PR TITLE
Add teacher salary listing, details, and status update endpoints

### DIFF
--- a/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
@@ -30,6 +30,19 @@ namespace OrbitsProject.API.Controllers
         }
 
         /// <summary>
+        /// Returns salary invoices optionally filtered by month or teacher.
+        /// </summary>
+        /// <param name="month">Optional month filter.</param>
+        /// <param name="teacherId">Optional teacher filter.</param>
+        [HttpGet("Invoices")]
+        [ProducesResponseType(typeof(IResponse<IEnumerable<TeacherInvoiceDto>>), 200)]
+        public async Task<IActionResult> GetInvoices([FromQuery] DateTime? month = null, [FromQuery] int? teacherId = null)
+        {
+            var result = await _teacherSallaryBll.GetInvoicesAsync(month, teacherId);
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Returns a monthly summary for a teacher including attendance breakdown and salary totals.
         /// </summary>
         /// <param name="teacherId">Optional teacher identifier. Defaults to the authenticated user.</param>
@@ -52,6 +65,31 @@ namespace OrbitsProject.API.Controllers
         public async Task<IActionResult> GetInvoice(int invoiceId)
         {
             var result = await _teacherSallaryBll.GetInvoiceByIdAsync(invoiceId);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Retrieves detailed information for a specific salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        [HttpGet("Invoice/{invoiceId:int}/Details")]
+        [ProducesResponseType(typeof(IResponse<TeacherSallaryDetailsDto>), 200)]
+        public async Task<IActionResult> GetInvoiceDetails(int invoiceId)
+        {
+            var result = await _teacherSallaryBll.GetInvoiceDetailsAsync(invoiceId);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Updates the payment status of a salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        /// <param name="dto">Payload describing the desired status.</param>
+        [HttpPut("Invoice/{invoiceId:int}/Status")]
+        [ProducesResponseType(typeof(IResponse<TeacherInvoiceDto>), 200)]
+        public async Task<IActionResult> UpdateInvoiceStatus(int invoiceId, [FromBody] UpdateTeacherSallaryStatusDto dto)
+        {
+            var result = await _teacherSallaryBll.UpdateInvoiceStatusAsync(invoiceId, dto, UserId);
             return Ok(result);
         }
     }

--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
@@ -23,9 +23,30 @@ namespace Orbits.GeneralProject.BLL.TeacherSallaryService
         Task<IResponse<TeacherMonthlySummaryDto>> GetMonthlySummaryAsync(int teacherId, DateTime? month = null);
 
         /// <summary>
+        /// Returns salary invoices optionally filtered by teacher and/or month.
+        /// </summary>
+        /// <param name="month">Optional month filter. The day component is ignored.</param>
+        /// <param name="teacherId">Optional teacher filter.</param>
+        Task<IResponse<IEnumerable<TeacherInvoiceDto>>> GetInvoicesAsync(DateTime? month = null, int? teacherId = null);
+
+        /// <summary>
+        /// Retrieves a salary invoice along with contextual summary information.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        Task<IResponse<TeacherSallaryDetailsDto>> GetInvoiceDetailsAsync(int invoiceId);
+
+        /// <summary>
         /// Retrieves a salary invoice by its identifier.
         /// </summary>
         /// <param name="invoiceId">The invoice identifier.</param>
         Task<IResponse<TeacherInvoiceDto>> GetInvoiceByIdAsync(int invoiceId);
+
+        /// <summary>
+        /// Updates the payment status of a salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        /// <param name="dto">Payload describing the desired status.</param>
+        /// <param name="userId">User identifier for audit columns.</param>
+        Task<IResponse<TeacherInvoiceDto>> UpdateInvoiceStatusAsync(int invoiceId, UpdateTeacherSallaryStatusDto dto, int userId);
     }
 }

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSallaryDetailsDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSallaryDetailsDto.cs
@@ -1,0 +1,20 @@
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    /// <summary>
+    /// Represents the detailed view of a teacher salary invoice including the
+    /// original invoice information and an optional monthly summary snapshot.
+    /// </summary>
+    public class TeacherSallaryDetailsDto
+    {
+        /// <summary>
+        /// The invoice information.
+        /// </summary>
+        public TeacherInvoiceDto Invoice { get; set; } = default!;
+
+        /// <summary>
+        /// Aggregated statistics for the invoice month. Can be <c>null</c> when the
+        /// teacher or month context is unavailable (e.g. missing teacher reference).
+        /// </summary>
+        public TeacherMonthlySummaryDto? MonthlySummary { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/UpdateTeacherSallaryStatusDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/UpdateTeacherSallaryStatusDto.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    /// <summary>
+    /// Payload used to update the payment status of a teacher salary invoice.
+    /// </summary>
+    public class UpdateTeacherSallaryStatusDto
+    {
+        /// <summary>
+        /// Indicates whether the invoice is marked as paid.
+        /// </summary>
+        public bool IsPayed { get; set; }
+
+        /// <summary>
+        /// Optional custom paid timestamp. When omitted and <see cref="IsPayed"/> is true
+        /// the current UTC timestamp is applied.
+        /// </summary>
+        public DateTime? PayedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add REST endpoints to list teacher salary invoices, fetch invoice details, and update invoice status with month/teacher filters
- extend the teacher salary BLL with filtering, detail retrieval, status update logic, and shared projections
- introduce DTOs for salary invoice details and update payloads reused by the new endpoints

## Testing
- `dotnet test Orbits.GeneralProject.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7b448a90832293d5a1cc81ed2721