### PR TITLE
Add teacher salary payment receipt handling endpoints

### DIFF
--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
@@ -48,5 +48,18 @@ namespace Orbits.GeneralProject.BLL.TeacherSallaryService
         /// <param name="dto">Payload describing the desired status.</param>
         /// <param name="userId">User identifier for audit columns.</param>
         Task<IResponse<TeacherInvoiceDto>> UpdateInvoiceStatusAsync(int invoiceId, UpdateTeacherSallaryStatusDto dto, int userId);
+
+        /// <summary>
+        /// Updates payment information for a salary invoice including optional receipt upload.
+        /// </summary>
+        /// <param name="dto">Form payload containing the payment data.</param>
+        /// <param name="userId">User identifier for audit columns.</param>
+        Task<IResponse<bool>> UpdatePaymentAsync(UpdateTeacherPaymentDto dto, int userId);
+
+        /// <summary>
+        /// Resolves the stored receipt path for the requested invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        Task<IResponse<string?>> GetPaymentReceiptPathAsync(int invoiceId);
     }
 }

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/UpdateTeacherPaymentDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/UpdateTeacherPaymentDto.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    /// <summary>
+    /// Payload used to update teacher salary payment metadata including the optional receipt file.
+    /// </summary>
+    public class UpdateTeacherPaymentDto
+    {
+        /// <summary>
+        /// Identifier of the teacher salary invoice to update.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Optional salary amount override.
+        /// </summary>
+        public double? Amount { get; set; }
+
+        /// <summary>
+        /// Uploaded receipt file (PDF). When provided, the stored receipt path is replaced.
+        /// </summary>
+        public IFormFile? ReceiptPath { get; set; }
+
+        /// <summary>
+        /// Indicates whether the invoice should be marked as paid.
+        /// </summary>
+        public bool? PayStatue { get; set; }
+
+        /// <summary>
+        /// Indicates whether the payment has been cancelled.
+        /// </summary>
+        public bool? IsCancelled { get; set; }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a DTO for teacher salary payment updates that includes the optional receipt upload
- extend the teacher salary BLL to accept the file service, update receipt paths, and expose the stored path for downloads
- expose API endpoints to stream teacher salary receipts and accept multipart payment updates from the admin UI

## Testing
- dotnet build Orbits.GeneralProject.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1ab93a4832282816646ed967ffa