### PR TITLE
Add admin teacher salary REST endpoints

### DIFF
--- a/OrbitsCameraProject.API/Controllers/AdminTeacherSalaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/AdminTeacherSalaryController.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Orbits.GeneralProject.BLL.BaseReponse;
+using Orbits.GeneralProject.BLL.Constants;
+using Orbits.GeneralProject.BLL.TeacherSallaryService;
+using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
+
+namespace OrbitsProject.API.Controllers
+{
+    /// <summary>
+    /// REST surface serving the teacher salary administration experience.
+    /// </summary>
+    [ApiController]
+    [Route("admin/teacher-salary")]
+    [EnableRateLimiting("FixedPolicy")]
+    public class AdminTeacherSalaryController : ControllerBase
+    {
+        private readonly ITeacherSallaryBLL _teacherSallaryBll;
+
+        public AdminTeacherSalaryController(ITeacherSallaryBLL teacherSallaryBll)
+        {
+            _teacherSallaryBll = teacherSallaryBll;
+        }
+
+        /// <summary>
+        /// Retrieves paged teacher salary invoices optionally filtered by month and teacher.
+        /// </summary>
+        /// <param name="month">Optional month filter (day component ignored).</param>
+        /// <param name="teacherId">Optional teacher identifier.</param>
+        [HttpGet("invoices")]
+        [ProducesResponseType(typeof(IResponse<IEnumerable<TeacherInvoiceDto>>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetInvoices([FromQuery] DateTime? month = null, [FromQuery] int? teacherId = null)
+        {
+            var response = await _teacherSallaryBll.GetInvoicesAsync(month, teacherId);
+            return Ok(response);
+        }
+
+        /// <summary>
+        /// Retrieves enriched invoice details for a specific teacher salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        [HttpGet("invoices/{invoiceId:int}/details")]
+        [ProducesResponseType(typeof(IResponse<TeacherSallaryDetailsDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetInvoiceDetails(int invoiceId)
+        {
+            var response = await _teacherSallaryBll.GetInvoiceDetailsAsync(invoiceId);
+            return Ok(response);
+        }
+
+        /// <summary>
+        /// Updates the payment status metadata for a teacher salary invoice.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        /// <param name="dto">Payload describing the new payment status.</param>
+        [HttpPatch("invoices/{invoiceId:int}/payment")]
+        [ProducesResponseType(typeof(IResponse<TeacherInvoiceDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateInvoicePayment(int invoiceId, [FromBody] UpdateTeacherSallaryStatusDto dto)
+        {
+            var response = await _teacherSallaryBll.UpdateInvoiceStatusAsync(invoiceId, dto, UserId);
+            return Ok(response);
+        }
+
+        /// <summary>
+        /// Uploads (or replaces) the payment receipt for a teacher salary invoice while optionally
+        /// updating payment metadata.
+        /// </summary>
+        /// <param name="invoiceId">The invoice identifier.</param>
+        /// <param name="form">Multipart form payload containing the receipt and metadata.</param>
+        [HttpPost("invoices/{invoiceId:int}/receipt")]
+        [ProducesResponseType(typeof(IResponse<TeacherInvoiceDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UploadInvoiceReceipt(int invoiceId, [FromForm] TeacherSalaryReceiptUploadDto form)
+        {
+            if (form.InvoiceId.HasValue && form.InvoiceId.Value != invoiceId)
+            {
+                var mismatchResponse = new Response<TeacherInvoiceDto>();
+                return Ok(mismatchResponse.AppendError(
+                    MessageCodes.InputValidationError,
+                    nameof(form.InvoiceId),
+                    "The invoice id in the payload does not match the requested resource."));
+            }
+
+            var updateDto = new UpdateTeacherPaymentDto
+            {
+                Id = invoiceId,
+                Amount = form.Amount,
+                PayStatue = form.PayStatue,
+                IsCancelled = form.IsCancelled,
+                ReceiptPath = form.Receipt
+            };
+
+            var updateResponse = await _teacherSallaryBll.UpdatePaymentAsync(updateDto, UserId);
+            if (!updateResponse.IsSuccess)
+            {
+                var failureResponse = new Response<TeacherInvoiceDto>();
+                if (updateResponse.Errors != null && updateResponse.Errors.Count > 0)
+                {
+                    return Ok(failureResponse.AppendErrors(updateResponse.Errors));
+                }
+
+                return Ok(failureResponse.CreateResponse(MessageCodes.Failed, "Unable to update the invoice payment."));
+            }
+
+            var invoiceResponse = await _teacherSallaryBll.GetInvoiceByIdAsync(invoiceId);
+            return Ok(invoiceResponse);
+        }
+
+        /// <summary>
+        /// Returns the monthly attendance and salary summary for a teacher.
+        /// </summary>
+        /// <param name="teacherId">Optional teacher identifier. Defaults to the authenticated user.</param>
+        /// <param name="month">Optional month filter (day component ignored).</param>
+        [HttpGet("monthly-summary")]
+        [ProducesResponseType(typeof(IResponse<TeacherMonthlySummaryDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMonthlySummary([FromQuery] int? teacherId = null, [FromQuery] DateTime? month = null)
+        {
+            var targetTeacherId = teacherId ?? UserId;
+            var response = await _teacherSallaryBll.GetMonthlySummaryAsync(targetTeacherId, month);
+            return Ok(response);
+        }
+
+        /// <summary>
+        /// Generates teacher salary invoices for the requested month (or the previous month by default).
+        /// </summary>
+        /// <param name="month">Optional month filter (day component ignored).</param>
+        [HttpPost("generate")]
+        [ProducesResponseType(typeof(IResponse<TeacherSallaryGenerationResultDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GenerateInvoices([FromQuery] DateTime? month = null)
+        {
+            var response = await _teacherSallaryBll.GenerateMonthlyInvoicesAsync(month, UserId);
+            return Ok(response);
+        }
+
+        private int UserId
+        {
+            get
+            {
+                var raw = User?.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrWhiteSpace(raw))
+                {
+                    throw new UnauthorizedAccessException("User id claim is missing from the token.");
+                }
+
+                if (!int.TryParse(raw, out var id))
+                {
+                    throw new UnauthorizedAccessException("User id claim is invalid (not a number).");
+                }
+
+                return id;
+            }
+        }
+    }
+}

--- a/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSalaryReceiptUploadDto.cs
+++ b/OrbitsGeneralProject.DTO/TeacherSallaryDtos/TeacherSalaryReceiptUploadDto.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Orbits.GeneralProject.DTO.TeacherSallaryDtos
+{
+    /// <summary>
+    /// Form payload used when uploading a teacher salary receipt through the admin REST surface.
+    /// </summary>
+    public class TeacherSalaryReceiptUploadDto
+    {
+        /// <summary>
+        /// Optional invoice identifier supplied by the client for payload validation.
+        /// </summary>
+        public int? InvoiceId { get; set; }
+
+        /// <summary>
+        /// Uploaded PDF receipt file.
+        /// </summary>
+        public IFormFile? Receipt { get; set; }
+
+        /// <summary>
+        /// Optional amount override.
+        /// </summary>
+        public double? Amount { get; set; }
+
+        /// <summary>
+        /// Optional payment status flag.
+        /// </summary>
+        public bool? PayStatue { get; set; }
+
+        /// <summary>
+        /// Optional cancellation flag.
+        /// </summary>
+        public bool? IsCancelled { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- expose a dedicated AdminTeacherSalaryController under `/admin/teacher-salary` with endpoints for listing invoices, viewing details, generating summaries, generating invoices, updating payment status, and uploading receipts
- wire the receipt upload flow through the existing teacher salary BLL so uploads update metadata and return the refreshed invoice payload
- add a DTO to bind the multipart form payload expected by the new receipt upload route

## Testing
- dotnet build Orbits.GeneralProject.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd5d436b8832291670d8443ae558c