### PR TITLE
Support monthly summaries for all teachers

### DIFF
--- a/OrbitsCameraProject.API/Controllers/AdminTeacherSalaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/AdminTeacherSalaryController.cs
@@ -110,16 +110,15 @@ namespace OrbitsProject.API.Controllers
         }
 
         /// <summary>
-        /// Returns the monthly attendance and salary summary for a teacher.
+        /// Returns monthly attendance and salary summaries.
         /// </summary>
-        /// <param name="teacherId">Optional teacher identifier. Defaults to the authenticated user.</param>
+        /// <param name="teacherId">Optional teacher identifier. When omitted summaries for all teachers are returned.</param>
         /// <param name="month">Optional month filter (day component ignored).</param>
         [HttpGet("monthly-summary")]
-        [ProducesResponseType(typeof(IResponse<TeacherMonthlySummaryDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IResponse<IEnumerable<TeacherMonthlySummaryDto>>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetMonthlySummary([FromQuery] int? teacherId = null, [FromQuery] DateTime? month = null)
         {
-            var targetTeacherId = teacherId ?? UserId;
-            var response = await _teacherSallaryBll.GetMonthlySummaryAsync(targetTeacherId, month);
+            var response = await _teacherSallaryBll.GetMonthlySummaryAsync(teacherId, month);
             return Ok(response);
         }
 

--- a/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
+++ b/OrbitsCameraProject.API/Controllers/TeacherSallaryController.cs
@@ -51,16 +51,15 @@ namespace OrbitsProject.API.Controllers
         }
 
         /// <summary>
-        /// Returns a monthly summary for a teacher including attendance breakdown and salary totals.
+        /// Returns monthly summaries including attendance breakdown and salary totals.
         /// </summary>
-        /// <param name="teacherId">Optional teacher identifier. Defaults to the authenticated user.</param>
+        /// <param name="teacherId">Optional teacher identifier. When omitted summaries for all teachers are returned.</param>
         /// <param name="month">Optional month (the day component is ignored).</param>
         [HttpGet("MonthlySummary")]
-        [ProducesResponseType(typeof(IResponse<TeacherMonthlySummaryDto>), 200)]
+        [ProducesResponseType(typeof(IResponse<IEnumerable<TeacherMonthlySummaryDto>>), 200)]
         public async Task<IActionResult> GetMonthlySummary([FromQuery] int? teacherId = null, [FromQuery] DateTime? month = null)
         {
-            var targetTeacherId = teacherId ?? UserId;
-            var result = await _teacherSallaryBll.GetMonthlySummaryAsync(targetTeacherId, month);
+            var result = await _teacherSallaryBll.GetMonthlySummaryAsync(teacherId, month);
             return Ok(result);
         }
 

--- a/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
+++ b/OrbitsGeneralProject.BLL/TeacherSallaryService/ITeacherSallaryBLL.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Orbits.GeneralProject.BLL.BaseReponse;
 using Orbits.GeneralProject.DTO.TeacherSallaryDtos;
 
@@ -16,11 +17,11 @@ namespace Orbits.GeneralProject.BLL.TeacherSallaryService
         Task<IResponse<TeacherSallaryGenerationResultDto>> GenerateMonthlyInvoicesAsync(DateTime? month = null, int? createdBy = null);
 
         /// <summary>
-        /// Calculates a teacher's activity summary for a specific month including attendance breakdown and salary totals.
+        /// Calculates teacher activity summaries for a specific month including attendance breakdowns and salary totals.
         /// </summary>
-        /// <param name="teacherId">The teacher identifier.</param>
+        /// <param name="teacherId">Optional teacher identifier filter.</param>
         /// <param name="month">Optional month filter. When omitted the previous calendar month is used.</param>
-        Task<IResponse<TeacherMonthlySummaryDto>> GetMonthlySummaryAsync(int teacherId, DateTime? month = null);
+        Task<IResponse<IEnumerable<TeacherMonthlySummaryDto>>> GetMonthlySummaryAsync(int? teacherId = null, DateTime? month = null);
 
         /// <summary>
         /// Returns salary invoices optionally filtered by teacher and/or month.


### PR DESCRIPTION
## Summary
- allow the salary service to gather summaries for every active teacher when no teacher id is supplied
- update the BLL contract and API controllers to return collections of teacher summaries instead of a single record

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfe5be15088322a911bbfe9bb0cc81