### PR TITLE
Add upcoming circle retrieval endpoint

### DIFF
--- a/OrbitsCameraProject.API/Controllers/CircleController.cs
+++ b/OrbitsCameraProject.API/Controllers/CircleController.cs
@@ -6,6 +6,7 @@ using Orbits.GeneralProject.BLL.StaticEnums;
 using Orbits.GeneralProject.Core.Entities;
 using Orbits.GeneralProject.DTO.CircleDto;
 using Orbits.GeneralProject.DTO.Paging;
+using System.Collections.Generic;
 
 namespace OrbitsProject.API.Controllers
 {
@@ -23,6 +24,10 @@ namespace OrbitsProject.API.Controllers
         [HttpGet("GetResultsByFilter"), ProducesResponseType(typeof(IResponse<PagedResultDto<CircleDto>>), 200)]
         public async Task<IActionResult> GetResultsByFilter([FromQuery] FilteredResultRequestDto paginationFilterModel ,int? managerId, int? teacherId)
            => Ok(_circleBLL.GetPagedList(paginationFilterModel, managerId, teacherId, UserId));
+
+        [HttpGet("Upcoming"), ProducesResponseType(typeof(IResponse<IEnumerable<UpcomingCircleDto>>), 200)]
+        public async Task<IActionResult> GetUpcoming([FromQuery] int? managerId = null, [FromQuery] int? teacherId = null, [FromQuery] int take = 4)
+           => Ok(await _circleBLL.GetUpcomingAsync(UserId, managerId, teacherId, take));
 
 
         [HttpPost("Create"), ProducesResponseType(typeof(IResponse<bool>), 200)]

--- a/OrbitsGeneralProject.BLL/CircleService/CircleBLL.cs
+++ b/OrbitsGeneralProject.BLL/CircleService/CircleBLL.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Math;
 using Orbits.GeneralProject.BLL.BaseReponse;
@@ -17,8 +18,11 @@ using Orbits.GeneralProject.DTO.Paging;
 using Orbits.GeneralProject.DTO.UserDto;
 using Orbits.GeneralProject.DTO.UserDtos;
 using Orbits.GeneralProject.Repositroy.Base;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Orbits.GeneralProject.BLL.CircleService
 {
@@ -30,6 +34,19 @@ namespace Orbits.GeneralProject.BLL.CircleService
 
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
+
+        private const int DefaultUpcomingTake = 4;
+
+        private static readonly IReadOnlyDictionary<int, DayOfWeek> DayOfWeekLookup = new Dictionary<int, DayOfWeek>
+        {
+            { (int)DaysEnum.Saturday, DayOfWeek.Saturday },
+            { (int)DaysEnum.Sunday, DayOfWeek.Sunday },
+            { (int)DaysEnum.Monday, DayOfWeek.Monday },
+            { (int)DaysEnum.Tuesday, DayOfWeek.Tuesday },
+            { (int)DaysEnum.Wednesday, DayOfWeek.Wednesday },
+            { (int)DaysEnum.Thursday, DayOfWeek.Thursday },
+            { (int)DaysEnum.Friday, DayOfWeek.Friday }
+        };
         public CircleBLL(IMapper mapper, IRepository<Circle> circleRepository,
              IUnitOfWork unitOfWork,
              IHostEnvironment hostEnvironment, IRepository<ManagerCircle> managerCircleRepository, IRepository<User> userRepository) : base(mapper)
@@ -139,6 +156,132 @@ namespace Orbits.GeneralProject.BLL.CircleService
             }
 
             return output.CreateResponse(page);
+        }
+
+
+        public async Task<IResponse<IEnumerable<UpcomingCircleDto>>> GetUpcomingAsync(
+            int userId,
+            int? managerId = null,
+            int? teacherId = null,
+            int take = DefaultUpcomingTake)
+        {
+            var output = new Response<IEnumerable<UpcomingCircleDto>>();
+
+            var currentUser = await _userRepository.GetByIdAsync(userId);
+            if (currentUser == null)
+                return output.AppendError(MessageCodes.NotFound);
+
+            var userType = (UserTypesEnum)(currentUser.UserTypeId ?? 0);
+
+            int? explicitManagerId = managerId.HasValue && managerId.Value > 0 ? managerId.Value : (int?)null;
+            int? explicitTeacherId = teacherId.HasValue && teacherId.Value > 0 ? teacherId.Value : (int?)null;
+
+            int effectiveTake = take > 0 ? take : DefaultUpcomingTake;
+
+            var query = _circleRepository
+                .GetAll()
+                .Include(c => c.Teacher)
+                .Include(c => c.ManagerCircles)
+                    .ThenInclude(mc => mc.Manager)
+                .Where(c => c.IsDeleted != true);
+
+            if (explicitManagerId.HasValue)
+            {
+                query = query.Where(c => c.ManagerCircles.Any(mc => mc.ManagerId == explicitManagerId.Value));
+            }
+            else if (userType == UserTypesEnum.Manager)
+            {
+                query = query.Where(c => c.ManagerCircles.Any(mc => mc.ManagerId == userId));
+            }
+
+            if (explicitTeacherId.HasValue)
+            {
+                query = query.Where(c => c.TeacherId == explicitTeacherId.Value);
+            }
+            else if (userType == UserTypesEnum.Teacher)
+            {
+                query = query.Where(c => c.TeacherId == userId);
+            }
+
+            if (userType == UserTypesEnum.Student)
+            {
+                query = query.Where(c => c.Users.Any(u => u.Id == userId));
+            }
+
+            var circles = await query.ToListAsync();
+
+            if (circles.Count == 0)
+            {
+                return output.CreateResponse(new List<UpcomingCircleDto>());
+            }
+
+            DateTime referenceUtc = DateTime.UtcNow;
+
+            var results = circles
+                .Select(circle => BuildUpcomingCircleDto(circle, referenceUtc))
+                .Where(dto => dto.NextOccurrenceDate.HasValue)
+                .OrderBy(dto => dto.NextOccurrenceDate)
+                .ThenBy(dto => dto.Id)
+                .Take(effectiveTake)
+                .ToList();
+
+            return output.CreateResponse(results);
+        }
+
+        private UpcomingCircleDto BuildUpcomingCircleDto(Circle circle, DateTime referenceUtc)
+        {
+            DateTime? nextOccurrence = CalculateNextOccurrence(referenceUtc, circle.Time);
+
+            var managers = circle.ManagerCircles?
+                .Where(mc => mc.ManagerId.HasValue && mc.Manager != null)
+                .Select(mc => new ManagerCirclesDto
+                {
+                    ManagerId = mc.ManagerId,
+                    Manager = mc.Manager?.FullName,
+                    CircleId = circle.Id,
+                    Circle = circle.Name
+                })
+                .ToList() ?? new List<ManagerCirclesDto>();
+
+            return new UpcomingCircleDto
+            {
+                Id = circle.Id,
+                Name = circle.Name,
+                DayId = circle.Time,
+                DayName = ResolveDayName(circle.Time),
+                NextOccurrenceDate = nextOccurrence,
+                TeacherId = circle.TeacherId,
+                TeacherName = circle.Teacher?.FullName,
+                Managers = managers
+            };
+        }
+
+        private static DateTime? CalculateNextOccurrence(DateTime referenceUtc, int? dayId)
+        {
+            if (!dayId.HasValue)
+                return null;
+
+            if (!DayOfWeekLookup.TryGetValue(dayId.Value, out var targetDay))
+                return null;
+
+            int currentDay = (int)referenceUtc.DayOfWeek;
+            int targetDayValue = (int)targetDay;
+
+            int daysToAdd = (targetDayValue - currentDay + 7) % 7;
+            DateTime nextDate = referenceUtc.Date.AddDays(daysToAdd);
+
+            return nextDate;
+        }
+
+        private static string? ResolveDayName(int? dayId)
+        {
+            if (!dayId.HasValue)
+                return null;
+
+            if (!Enum.IsDefined(typeof(DaysEnum), dayId.Value))
+                return null;
+
+            return ((DaysEnum)dayId.Value).ToString();
         }
 
 

--- a/OrbitsGeneralProject.BLL/CircleService/ICircleBLL.cs
+++ b/OrbitsGeneralProject.BLL/CircleService/ICircleBLL.cs
@@ -17,6 +17,8 @@ namespace Orbits.GeneralProject.BLL.CircleService
     {
         public IResponse<PagedResultDto<CircleDto>> GetPagedList(FilteredResultRequestDto pagedDto, int? managerId, int? teacherId, int userId);
 
+        Task<IResponse<IEnumerable<UpcomingCircleDto>>> GetUpcomingAsync(int userId, int? managerId = null, int? teacherId = null, int take = 4);
+
         Task<IResponse<bool>> AddAsync(CreateCircleDto model, int userId);
 
         Task<IResponse<bool>> Update(UpdateCircleDto dto, int userId);

--- a/OrbitsGeneralProject.BLL/StaticEnums/DaysEnum.cs
+++ b/OrbitsGeneralProject.BLL/StaticEnums/DaysEnum.cs
@@ -1,0 +1,13 @@
+namespace Orbits.GeneralProject.BLL.StaticEnums
+{
+    public enum DaysEnum
+    {
+        Saturday = 1,
+        Sunday = 2,
+        Monday = 3,
+        Tuesday = 4,
+        Wednesday = 5,
+        Thursday = 6,
+        Friday = 7
+    }
+}

--- a/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Orbits.GeneralProject.DTO.CircleDto
+{
+    public class UpcomingCircleDto
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public int? DayId { get; set; }
+        public string? DayName { get; set; }
+        public DateTime? NextOccurrenceDate { get; set; }
+        public int? TeacherId { get; set; }
+        public string? TeacherName { get; set; }
+        public ICollection<ManagerCirclesDto>? Managers { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a DaysEnum definition and DTO for exposing upcoming circle information
- implement BLL logic to calculate the next occurrence per circle for the current, manager, or teacher context
- surface a new API endpoint to fetch upcoming circles for dashboard usage

## Testing
- dotnet build *(fails: .NET SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fc8dfa848322855c4fe8b89c5baf