### PR TITLE
Fix SqlClient type mismatch

### DIFF
--- a/OrbitsCameraProject.API/Program.cs
+++ b/OrbitsCameraProject.API/Program.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;

--- a/OrbitsGeneralProject.Repositroy/Base/BaseRepository.cs
+++ b/OrbitsGeneralProject.Repositroy/Base/BaseRepository.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 using System;
 using System.Collections;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using Orbits.GeneralProject.Core.Entities;


### PR DESCRIPTION
## Summary
- replace System.Data.SqlClient usage with Microsoft.Data.SqlClient in the repository and API startup
- ensure custom SQL parameters align with the EF Core SQL Server provider to prevent casting exceptions

## Testing
- dotnet build Orbits.GeneralProject.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d13c6d25948322a0efcc7a4de4de7e