### PR TITLE
Support multiple scheduling days per circle

### DIFF
--- a/OrbitsGeneralProject.BLL/Constants/OribitsConstants.cs
+++ b/OrbitsGeneralProject.BLL/Constants/OribitsConstants.cs
@@ -132,6 +132,8 @@ namespace Orbits.GeneralProject.BLL.Constants
         public const string NAME_Must_Not_Null = "الإسم لا يمكن اي يكون فارغا";
         public const string Name_Max_Length = "لا يمكن أن يزيد اسم الحلقة عن 250 حرف !";
         public const string ValidName = "لا يجب وضع علامات خاصة في الإسم";
+        public const string DaysRequired = "يجب اختيار الأيام";
+        public const string DaysMustBeMoreThanZero = "يجب اختيار رقم اكبر من صفر في الأيام";
         public const string DayRequired = "اليوم مطلوب";
         public const string StartTimeRequired = "وقت البداية مطلوب";
         public const string StartTimeInvalid = "وقت البداية غير صحيح";

--- a/OrbitsGeneralProject.BLL/Mapping/DtoToEntityMappingProfile.cs
+++ b/OrbitsGeneralProject.BLL/Mapping/DtoToEntityMappingProfile.cs
@@ -16,10 +16,8 @@ namespace Orbits.GeneralProject.BLL.Mapping
 
             CreateMap<DTO.UserDto.CreateUserDto, User>();
             CreateMap<UpdateUserDto, User>();
-            CreateMap<CreateCircleDto, Circle>()
-                .ForMember(d => d.Time, o => o.MapFrom(s => s.DayId));
-            CreateMap<UpdateCircleDto, Circle>()
-                .ForMember(d => d.Time, o => o.MapFrom(s => s.DayId));
+            CreateMap<CreateCircleDto, Circle>();
+            CreateMap<UpdateCircleDto, Circle>();
             CreateMap<ManagerCirclesDto, ManagerCircle>();
             CreateMap<CircleReportAddDto, CircleReport>()
             .ForMember(x => x.StudentId, xx => xx.MapFrom(c => c.StudentId))

--- a/OrbitsGeneralProject.BLL/Mapping/EntityToDtoMappingProfile.cs
+++ b/OrbitsGeneralProject.BLL/Mapping/EntityToDtoMappingProfile.cs
@@ -12,6 +12,8 @@ using Orbits.GeneralProject.DTO.StudentSubscribDtos.StudentPaymentDtos;
 using Orbits.GeneralProject.DTO.SubscribeDtos;
 using Orbits.GeneralProject.DTO.UserDto;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Orbits.GeneralProject.BLL.Mapping
 {
@@ -24,13 +26,23 @@ namespace Orbits.GeneralProject.BLL.Mapping
             CreateMap<Circle, CircleDto>()
                 .ForMember(d => d.Managers, o => o.MapFrom(s => s.ManagerCircles))
                 .ForMember(d => d.Students, o => o.MapFrom(s => s.Users.Where(X => X.UserTypeId == (int)UserTypesEnum.Student)))
-                .ForMember(d => d.DayId, o => o.MapFrom(s => s.Time))
-                .ForMember(d => d.DayName, o => o.MapFrom(s =>
-                    s.Time.HasValue && Enum.IsDefined(typeof(DaysEnum), s.Time.Value)
-                        ? ((DaysEnum)s.Time.Value).ToString()
-                        : null))
-                .ForMember(d => d.StartTime, o => o.MapFrom(s => s.StartTime))
-;
+                .ForMember(d => d.DayIds, o => o.MapFrom(s =>
+                    s.CircleDays != null
+                        ? s.CircleDays
+                            .Where(cd => cd.DayId.HasValue)
+                            .Select(cd => cd.DayId!.Value)
+                            .Distinct()
+                            .ToList()
+                        : new List<int>()))
+                .ForMember(d => d.DayNames, o => o.MapFrom(s =>
+                    s.CircleDays != null
+                        ? s.CircleDays
+                            .Where(cd => cd.DayId.HasValue && Enum.IsDefined(typeof(DaysEnum), cd.DayId!.Value))
+                            .Select(cd => ((DaysEnum)cd.DayId!.Value).ToString())
+                            .Distinct()
+                            .ToList()
+                        : new List<string>()))
+                .ForMember(d => d.StartTime, o => o.MapFrom(s => s.StartTime));
             CreateMap<User, UserReturnDto>();
             CreateMap<User, ManagerDto>();
             CreateMap<User, UserLockUpDto>()

--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
@@ -5,6 +5,7 @@ using Orbits.GeneralProject.BLL.Constants;
 using Orbits.GeneralProject.BLL.StaticEnums;
 using Orbits.GeneralProject.DTO.CircleDto;
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Orbits.GeneralProject.BLL.Validation.CircleValidation;
@@ -18,9 +19,12 @@ public class CircleUpdateValidation : AbstractValidator<UpdateCircleDto>
         RuleFor(l => l.Name).Matches(new Regex(@"^(?!.*\d_)(?!.*_\d)[a-zA-Z0-9ء-ي ]+$"))
 .WithMessage(CircleValidationResponseConstants.ValidName);
 
-        RuleFor(l => l.DayId)
-            .NotNull().WithMessage(CircleValidationResponseConstants.DayRequired)
-            .Must(day => day.HasValue && Enum.IsDefined(typeof(DaysEnum), day.Value))
+        RuleFor(l => l.DayIds)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
+            .Must(days => days != null && days.Count > 0)
+            .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
+            .Must(days => days != null && days.All(day => Enum.IsDefined(typeof(DaysEnum), day)))
             .WithMessage(CircleValidationResponseConstants.DayRequired);
 
         RuleFor(l => l.StartTime)

--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
@@ -3,6 +3,7 @@ using Orbits.GeneralProject.BLL.Constants;
 using Orbits.GeneralProject.BLL.StaticEnums;
 using Orbits.GeneralProject.DTO.CircleDto;
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Orbits.GeneralProject.BLL.Validation.CircleValidation;
@@ -16,9 +17,12 @@ public class CircleValidation : AbstractValidator<CreateCircleDto>
         RuleFor(l => l.Name).Matches(new Regex(@"^(?!.*\d_)(?!.*_\d)[a-zA-Z0-9ء-ي ]+$"))
     .WithMessage(CircleValidationResponseConstants.ValidName);
 
-        RuleFor(l => l.DayId)
-            .NotNull().WithMessage(CircleValidationResponseConstants.DayRequired)
-            .Must(day => day.HasValue && Enum.IsDefined(typeof(DaysEnum), day.Value))
+        RuleFor(l => l.DayIds)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
+            .Must(days => days != null && days.Count > 0)
+            .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
+            .Must(days => days != null && days.All(day => Enum.IsDefined(typeof(DaysEnum), day)))
             .WithMessage(CircleValidationResponseConstants.DayRequired);
 
         RuleFor(l => l.StartTime)

--- a/OrbitsGeneralProject.Core/Entities/Circle.cs
+++ b/OrbitsGeneralProject.Core/Entities/Circle.cs
@@ -10,6 +10,7 @@ namespace Orbits.GeneralProject.Core.Entities
             CircleReports = new HashSet<CircleReport>();
             ManagerCircles = new HashSet<ManagerCircle>();
             Users = new HashSet<User>();
+            CircleDays = new HashSet<CircleDay>();
         }
 
         public int Id { get; set; }
@@ -20,12 +21,12 @@ namespace Orbits.GeneralProject.Core.Entities
         public string? Name { get; set; }
         public bool? IsDeleted { get; set; }
         public int? TeacherId { get; set; }
-        public int? Time { get; set; }
         public TimeSpan? StartTime { get; set; }
 
         public virtual User? Teacher { get; set; }
         public virtual ICollection<CircleReport> CircleReports { get; set; }
         public virtual ICollection<ManagerCircle> ManagerCircles { get; set; }
         public virtual ICollection<User> Users { get; set; }
+        public virtual ICollection<CircleDay> CircleDays { get; set; }
     }
 }

--- a/OrbitsGeneralProject.Core/Entities/CircleDay.cs
+++ b/OrbitsGeneralProject.Core/Entities/CircleDay.cs
@@ -1,0 +1,18 @@
+using System;
+using Orbits.GeneralProject.Core.Infrastructure;
+
+namespace Orbits.GeneralProject.Core.Entities
+{
+    public partial class CircleDay : EntityBase
+    {
+        public int Id { get; set; }
+        public int? CreatedBy { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public int? ModefiedBy { get; set; }
+        public DateTime? ModefiedAt { get; set; }
+        public int? DayId { get; set; }
+        public int? CircleId { get; set; }
+
+        public virtual Circle? Circle { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.Core/Entities/OrbitsContext.cs
+++ b/OrbitsGeneralProject.Core/Entities/OrbitsContext.cs
@@ -12,6 +12,7 @@ namespace Orbits.GeneralProject.Core.Entities
         public virtual DbSet<ChallengeRole> ChallengeRoles { get; set; } = null!;
         public virtual DbSet<Circle> Circles { get; set; } = null!;
         public virtual DbSet<CircleReport> CircleReports { get; set; } = null!;
+        public virtual DbSet<CircleDay> CircleDays { get; set; } = null!;
         public virtual DbSet<Family> Families { get; set; } = null!;
         public virtual DbSet<Governorate> Governorates { get; set; } = null!;
         public virtual DbSet<ManagerCircle> ManagerCircles { get; set; } = null!;
@@ -109,6 +110,20 @@ namespace Orbits.GeneralProject.Core.Entities
                     .WithMany(p => p.Circles)
                     .HasForeignKey(d => d.TeacherId)
                     .HasConstraintName("FK_Circle_Teacher");
+            });
+
+            modelBuilder.Entity<CircleDay>(entity =>
+            {
+                entity.ToTable("CircleDay");
+
+                entity.Property(e => e.CreatedAt).HasColumnType("datetime");
+
+                entity.Property(e => e.ModefiedAt).HasColumnType("datetime");
+
+                entity.HasOne(d => d.Circle)
+                    .WithMany(p => p.CircleDays)
+                    .HasForeignKey(d => d.CircleId)
+                    .HasConstraintName("FK_CircleDay_Circle");
             });
 
             modelBuilder.Entity<CircleReport>(entity =>

--- a/OrbitsGeneralProject.Core/Infrastructure/ApplicationDbContext.cs
+++ b/OrbitsGeneralProject.Core/Infrastructure/ApplicationDbContext.cs
@@ -147,6 +147,7 @@ namespace Orbits.GeneralProject.Core.Infrastructure
           
             modelBuilder.Entity<RefreshToken>().Ignore(f => f.IsDeleted);
             modelBuilder.Entity<ManagerCircle>().Ignore(f => f.IsDeleted);
+            modelBuilder.Entity<CircleDay>().Ignore(f => f.IsDeleted);
             modelBuilder.Entity<Nationality>().Ignore(f => f.IsDeleted);
             modelBuilder.Entity<Governorate>().Ignore(f => f.IsDeleted);
             modelBuilder.Entity<StudentSubscribe>().Ignore(f => f.IsDeleted);

--- a/OrbitsGeneralProject.DTO/CircleDto/CircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/CircleDto.cs
@@ -1,7 +1,7 @@
-using Orbits.GeneralProject.Core.Entities;
 using Orbits.GeneralProject.DTO.LockUpDtos;
 using Orbits.GeneralProject.DTO.UserDto;
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Orbits.GeneralProject.DTO.CircleDto
@@ -11,15 +11,14 @@ namespace Orbits.GeneralProject.DTO.CircleDto
 
         public int Id { get; set; }
         public string? Name { get; set; }
-        public int? Time { get; set; }
         public int? TeacherId { get; set; }
         public UserLockUpDto? Teacher { get; set; }
 
         [JsonPropertyName("day")]
-        public int? DayId { get; set; }
+        public ICollection<int>? DayIds { get; set; }
 
         [JsonPropertyName("dayName")]
-        public string? DayName { get; set; }
+        public ICollection<string>? DayNames { get; set; }
 
         [JsonPropertyName("time")]
         public TimeSpan? StartTime { get; set; }

--- a/OrbitsGeneralProject.DTO/CircleDto/CreateCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/CreateCircleDto.cs
@@ -1,20 +1,19 @@
-using Orbits.GeneralProject.Core.Entities;
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Orbits.GeneralProject.DTO.CircleDto
 {
     public class CreateCircleDto
     {
-       
+
 
         public string? Name { get; set; }
-        public int? Time { get; set; }
 
         public int? TeacherId { get; set; }
 
         [JsonPropertyName("day")]
-        public int? DayId { get; set; }
+        public List<int>? DayIds { get; set; } = new List<int>();
 
         [JsonPropertyName("time")]
         public TimeSpan? StartTime { get; set; }

--- a/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
@@ -8,8 +8,14 @@ namespace Orbits.GeneralProject.DTO.CircleDto
     {
         public int Id { get; set; }
         public string? Name { get; set; }
-        public int? DayId { get; set; }
-        public string? DayName { get; set; }
+        public int? NextDayId { get; set; }
+        public string? NextDayName { get; set; }
+
+        [JsonPropertyName("day")]
+        public ICollection<int>? DayIds { get; set; }
+
+        [JsonPropertyName("dayName")]
+        public ICollection<string>? DayNames { get; set; }
         public DateTime? NextOccurrenceDate { get; set; }
         [JsonPropertyName("time")]
         public TimeSpan? StartTime { get; set; }

--- a/OrbitsGeneralProject.DTO/CircleDto/UpdateCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/UpdateCircleDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Orbits.GeneralProject.DTO.CircleDto
@@ -7,12 +8,11 @@ namespace Orbits.GeneralProject.DTO.CircleDto
     {
         public int Id { get; set; }
         public string? Name { get; set; }
-        public int? Time { get; set; }
 
         public int? TeacherId { get; set; }
 
         [JsonPropertyName("day")]
-        public int? DayId { get; set; }
+        public List<int>? DayIds { get; set; } = new List<int>();
 
         [JsonPropertyName("time")]
         public TimeSpan? StartTime { get; set; }


### PR DESCRIPTION
## Summary
- add a CircleDay entity and EF configuration to represent many-to-many relations between circles and scheduled days
- update circle DTOs and validation to work with day collections and expose next-occurrence metadata
- refactor CircleBLL logic to manage circle day assignments and compute upcoming sessions across multiple days

## Testing
- dotnet build Orbits.GeneralProject.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d14123c8248322a0572e881405fb6e