### PR TITLE
Update circle day management to support many-to-many

### DIFF
--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
@@ -2,7 +2,6 @@
 
 using FluentValidation;
 using Orbits.GeneralProject.BLL.Constants;
-using Orbits.GeneralProject.BLL.StaticEnums;
 using Orbits.GeneralProject.DTO.CircleDto;
 using System;
 using System.Linq;
@@ -24,7 +23,7 @@ public class CircleUpdateValidation : AbstractValidator<UpdateCircleDto>
             .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
             .Must(days => days != null && days.Count > 0)
             .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
-            .Must(days => days != null && days.All(day => Enum.IsDefined(typeof(DaysEnum), day)))
+            .Must(days => days != null && days.All(day => day > 0))
             .WithMessage(CircleValidationResponseConstants.DayRequired);
 
         RuleFor(l => l.StartTime)

--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
@@ -1,6 +1,5 @@
 ﻿using FluentValidation;
 using Orbits.GeneralProject.BLL.Constants;
-using Orbits.GeneralProject.BLL.StaticEnums;
 using Orbits.GeneralProject.DTO.CircleDto;
 using System;
 using System.Linq;
@@ -22,7 +21,7 @@ public class CircleValidation : AbstractValidator<CreateCircleDto>
             .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
             .Must(days => days != null && days.Count > 0)
             .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
-            .Must(days => days != null && days.All(day => Enum.IsDefined(typeof(DaysEnum), day)))
+            .Must(days => days != null && days.All(day => day > 0))
             .WithMessage(CircleValidationResponseConstants.DayRequired);
 
         RuleFor(l => l.StartTime)


### PR DESCRIPTION
## Summary
- inject the day repository into the circle service so day selections are validated against the database
- update add/update/get logic to manage CircleDay links and hydrate day names from the new many-to-many schema
- relax circle validators to accept positive day identifiers instead of hard-coded enum values

## Testing
- `dotnet build Orbits.GeneralProject.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d148becdf88322983d7393d9d07924