### PR TITLE
Refactor circle scheduling data model

### DIFF
--- a/OrbitsGeneralProject.BLL/Mapping/EntityToDtoMappingProfile.cs
+++ b/OrbitsGeneralProject.BLL/Mapping/EntityToDtoMappingProfile.cs
@@ -26,23 +26,16 @@ namespace Orbits.GeneralProject.BLL.Mapping
             CreateMap<Circle, CircleDto>()
                 .ForMember(d => d.Managers, o => o.MapFrom(s => s.ManagerCircles))
                 .ForMember(d => d.Students, o => o.MapFrom(s => s.Users.Where(X => X.UserTypeId == (int)UserTypesEnum.Student)))
-                .ForMember(d => d.DayIds, o => o.MapFrom(s =>
-                    s.CircleDays != null
-                        ? s.CircleDays
-                            .Where(cd => cd.DayId.HasValue)
-                            .Select(cd => cd.DayId!.Value)
-                            .Distinct()
-                            .ToList()
-                        : new List<int>()))
-                .ForMember(d => d.DayNames, o => o.MapFrom(s =>
-                    s.CircleDays != null
-                        ? s.CircleDays
-                            .Where(cd => cd.DayId.HasValue && Enum.IsDefined(typeof(DaysEnum), cd.DayId!.Value))
-                            .Select(cd => ((DaysEnum)cd.DayId!.Value).ToString())
-                            .Distinct()
-                            .ToList()
-                        : new List<string>()))
-                .ForMember(d => d.StartTime, o => o.MapFrom(s => s.StartTime));
+                .ForMember(d => d.Days, o => o.MapFrom(s => s.CircleDays));
+            CreateMap<CircleDay, CircleDayDto>()
+                .ForMember(d => d.DayId, o => o.MapFrom(s => s.DayId.HasValue ? s.DayId.Value : 0))
+                .ForMember(d => d.Time, o => o.MapFrom(s => s.Time))
+                .ForMember(d => d.DayName, o => o.MapFrom(s =>
+                    s.Day != null
+                        ? s.Day.NameOfDay
+                        : (s.DayId.HasValue && Enum.IsDefined(typeof(DaysEnum), s.DayId.Value)
+                            ? ((DaysEnum)s.DayId.Value).ToString()
+                            : null)));
             CreateMap<User, UserReturnDto>();
             CreateMap<User, ManagerDto>();
             CreateMap<User, UserLockUpDto>()

--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleUpdateValidation.cs
@@ -18,19 +18,21 @@ public class CircleUpdateValidation : AbstractValidator<UpdateCircleDto>
         RuleFor(l => l.Name).Matches(new Regex(@"^(?!.*\d_)(?!.*_\d)[a-zA-Z0-9ء-ي ]+$"))
 .WithMessage(CircleValidationResponseConstants.ValidName);
 
-        RuleFor(l => l.DayIds)
+        RuleFor(l => l.Days)
             .Cascade(CascadeMode.Stop)
             .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
             .Must(days => days != null && days.Count > 0)
             .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
-            .Must(days => days != null && days.All(day => day > 0))
-            .WithMessage(CircleValidationResponseConstants.DayRequired);
-
-        RuleFor(l => l.StartTime)
-            .NotNull().WithMessage(CircleValidationResponseConstants.StartTimeRequired)
-            .Must(time => !time.HasValue || (time.Value >= TimeSpan.Zero && time.Value < TimeSpan.FromDays(1)))
+            .Must(days => days != null && days.All(day => day.DayId > 0))
+            .WithMessage(CircleValidationResponseConstants.DayRequired)
+            .Must(days => days != null && days.All(day => day.Time.HasValue))
+            .WithMessage(CircleValidationResponseConstants.StartTimeRequired)
+            .Must(days => days != null && days.All(day => IsValidTime(day.Time)))
             .WithMessage(CircleValidationResponseConstants.StartTimeInvalid);
 
     }
+
+    private static bool IsValidTime(TimeSpan? time)
+        => time.HasValue && time.Value >= TimeSpan.Zero && time.Value < TimeSpan.FromDays(1);
 
 }

--- a/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
+++ b/OrbitsGeneralProject.BLL/Validation/CircleValidation/CircleValidation.cs
@@ -16,19 +16,21 @@ public class CircleValidation : AbstractValidator<CreateCircleDto>
         RuleFor(l => l.Name).Matches(new Regex(@"^(?!.*\d_)(?!.*_\d)[a-zA-Z0-9ء-ي ]+$"))
     .WithMessage(CircleValidationResponseConstants.ValidName);
 
-        RuleFor(l => l.DayIds)
+        RuleFor(l => l.Days)
             .Cascade(CascadeMode.Stop)
             .NotNull().WithMessage(CircleValidationResponseConstants.DaysRequired)
             .Must(days => days != null && days.Count > 0)
             .WithMessage(CircleValidationResponseConstants.DaysMustBeMoreThanZero)
-            .Must(days => days != null && days.All(day => day > 0))
-            .WithMessage(CircleValidationResponseConstants.DayRequired);
-
-        RuleFor(l => l.StartTime)
-            .NotNull().WithMessage(CircleValidationResponseConstants.StartTimeRequired)
-            .Must(time => !time.HasValue || (time.Value >= TimeSpan.Zero && time.Value < TimeSpan.FromDays(1)))
+            .Must(days => days != null && days.All(day => day.DayId > 0))
+            .WithMessage(CircleValidationResponseConstants.DayRequired)
+            .Must(days => days != null && days.All(day => day.Time.HasValue))
+            .WithMessage(CircleValidationResponseConstants.StartTimeRequired)
+            .Must(days => days != null && days.All(day => IsValidTime(day.Time)))
             .WithMessage(CircleValidationResponseConstants.StartTimeInvalid);
 
     }
+
+    private static bool IsValidTime(TimeSpan? time)
+        => time.HasValue && time.Value >= TimeSpan.Zero && time.Value < TimeSpan.FromDays(1);
 
 }

--- a/OrbitsGeneralProject.DTO/CircleDto/CircleDayDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/CircleDayDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Orbits.GeneralProject.DTO.CircleDto
+{
+    public class CircleDayRequestDto
+    {
+        [JsonPropertyName("dayId")]
+        public int DayId { get; set; }
+
+        [JsonPropertyName("time")]
+        public TimeSpan? Time { get; set; }
+    }
+
+    public class CircleDayDto : CircleDayRequestDto
+    {
+        [JsonPropertyName("dayName")]
+        public string? DayName { get; set; }
+    }
+}

--- a/OrbitsGeneralProject.DTO/CircleDto/CircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/CircleDto.cs
@@ -8,7 +8,6 @@ namespace Orbits.GeneralProject.DTO.CircleDto
 {
     public class CircleDto
     {
-
         public int Id { get; set; }
         public string? Name { get; set; }
         public int? TeacherId { get; set; }
@@ -23,10 +22,11 @@ namespace Orbits.GeneralProject.DTO.CircleDto
         [JsonPropertyName("startTime")]
         public TimeSpan? StartTime { get; set; }
 
+        [JsonPropertyName("days")]
+        public ICollection<CircleDayDto>? Days { get; set; }
+
         public ICollection<ManagerCirclesDto>? Managers { get; set; }
 
         public ICollection<UserReturnDto>? Students { get; set; }
-
-
     }
 }

--- a/OrbitsGeneralProject.DTO/CircleDto/CreateCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/CreateCircleDto.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -6,20 +5,15 @@ namespace Orbits.GeneralProject.DTO.CircleDto
 {
     public class CreateCircleDto
     {
-
-
         public string? Name { get; set; }
 
         public int? TeacherId { get; set; }
 
-        public List<int>? DayIds { get; set; } = new List<int>();
-
-        public TimeSpan? StartTime { get; set; }
+        [JsonPropertyName("days")]
+        public List<CircleDayRequestDto>? Days { get; set; } = new List<CircleDayRequestDto>();
 
         public List<int>? Managers { get; set; } = new List<int>();
 
         public List<int>? StudentsIds { get; set; } = new List<int>();
-
-
     }
 }

--- a/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/UpcomingCircleDto.cs
@@ -22,5 +22,8 @@ namespace Orbits.GeneralProject.DTO.CircleDto
         public int? TeacherId { get; set; }
         public string? TeacherName { get; set; }
         public ICollection<ManagerCirclesDto>? Managers { get; set; }
+
+        [JsonPropertyName("days")]
+        public ICollection<CircleDayDto>? Days { get; set; }
     }
 }

--- a/OrbitsGeneralProject.DTO/CircleDto/UpdateCircleDto.cs
+++ b/OrbitsGeneralProject.DTO/CircleDto/UpdateCircleDto.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -11,10 +10,8 @@ namespace Orbits.GeneralProject.DTO.CircleDto
 
         public int? TeacherId { get; set; }
 
-        [JsonPropertyName("day")]
-        public List<int>? DayIds { get; set; } = new List<int>();
-
-        public TimeSpan? StartTime { get; set; }
+        [JsonPropertyName("days")]
+        public List<CircleDayRequestDto>? Days { get; set; } = new List<CircleDayRequestDto>();
 
         public List<int>? Managers { get; set; }
 


### PR DESCRIPTION
## Summary
- introduce dedicated circle day DTOs and expose schedules on create/update/response contracts
- update AutoMapper and circle BLL logic to manage per-day start times, metadata, and upcoming calculations
- validate incoming day/time combinations during circle creation and updates

## Testing
- `dotnet build Orbits.GeneralProject.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a2e862988322b879ae3440b2cefd