### PR TITLE
Fix circle report update billing recalculation

### DIFF
--- a/OrbitsGeneralProject.BLL/CircleReportService/CircleReportBLL.cs
+++ b/OrbitsGeneralProject.BLL/CircleReportService/CircleReportBLL.cs
@@ -283,29 +283,10 @@ namespace Orbits.GeneralProject.BLL.CircleReportService
             bool prevCounts = CountsForBilling(prevStatusId);
             bool newCounts = CountsForBilling(newStatusId);
 
-            // 5) ????? ???? ????? ?????? ??? ?????? ??????
-            // Four cases:
-            // A) prev: count & new: count   -> ???/????? ??? ??????? ???
-            // B) prev: count & new: noCount -> ????? ?? ????? ??????? ???????
-            // C) prev: noCount & new: count -> ??? ?? ????? ??????? ???????
-            // D) prev: noCount & new: noCount -> ?? ?????
-            int deltaRemaining = 0;
-            if (prevCounts && newCounts)
-            {
-                // remaining -= (new - prev)  ==> delta = -(new - prev)
-                deltaRemaining = -(newMinutes - prevMinutes);
-            }
-            else if (prevCounts && !newCounts)
-            {
-                // ???? ???? ??????? ???? ???? ????? ??????
-                deltaRemaining = +prevMinutes;
-            }
-            else if (!prevCounts && newCounts)
-            {
-                // ???? ???? ??????? ???????
-                deltaRemaining = -newMinutes;
-            }
-            // else: 0
+            // 5) ????? ??????? ??? ??????? ?? ?????? ?????? ?????? ??? ?? ??? ??????
+            int chargedPrevMinutes = prevCounts ? prevMinutes : 0;
+            int chargedNewMinutes = newCounts ? newMinutes : 0;
+            int deltaRemaining = chargedPrevMinutes - chargedNewMinutes;
           
             studentSubscribe.RemainingMinutes += deltaRemaining;
             studentSubscribe.ModefiedAt = DateTime.UtcNow;
@@ -317,32 +298,40 @@ namespace Orbits.GeneralProject.BLL.CircleReportService
             report.ModifiedAt = DateTime.UtcNow;
             report.StudentId = student.Id; // ????? ?????
             report.IsDeleted = false;
+            report.Minutes = chargedNewMinutes;
+            report.AttendStatueId = newStatusId;
 
             // 7) ???? ?????? ????? ??? ?????? ??????? ??? (????/???? ???? ???)
             var teacherReport = _teacherReportRecordRepository
                 .Where(x => x.CircleReportId == model.Id).FirstOrDefault();
 
+            var subscribeType = studentSubscribe.StudentSubscribeType;
+            var pricePerUnit = ResolveHourlyRate(subscribeType);
+            var teacherSalary = CalculateTeacherSalary(pricePerUnit, chargedNewMinutes);
+
             if (teacherReport != null)
             {
-                // ??? ???????/?????? ??? ??? ???????? ???????
-                var subscribeType = studentSubscribe.StudentSubscribeType;
-                var pricePerUnit = ResolveHourlyRate(subscribeType);
-
-                if (newCounts)
-                {
-                    teacherReport.Minutes = newMinutes;
-                    teacherReport.CircleSallary = CalculateTeacherSalary(pricePerUnit, newMinutes);
-                }
-                else
-                {
-                    // ????? ?????? ??? ?????? ????
-                    teacherReport.Minutes = 0;
-                    teacherReport.CircleSallary = 0;
-                }
+                teacherReport.Minutes = chargedNewMinutes;
+                teacherReport.CircleSallary = newCounts ? teacherSalary : 0;
 
                 teacherReport.ModefiedAt = DateTime.UtcNow;
                 teacherReport.CreatedAt = report.CreationTime;
                 teacherReport.ModefiedBy = userId;
+            }
+            else if (newCounts)
+            {
+                var teacherReportRecord = new TeacherReportRecord
+                {
+                    CreatedAt = report.CreationTime,
+                    StudentId = student.Id,
+                    TeacherId = teacher.Id,
+                    IsDeleted = false,
+                    Minutes = chargedNewMinutes,
+                    CircleReportId = report.Id,
+                    CircleSallary = teacherSalary
+                };
+
+                _teacherReportRecordRepository.Add(teacherReportRecord);
             }
 
             // 8) ??? ?? ??? ?????? ?????


### PR DESCRIPTION
### Motivation
- Fix a billing bug where changing a report from a billable attendance (`Present`/`AbsentWithoutExcuse`) to a non‑billable attendance (`AbsentWithExcuse`) did not return minutes to the student nor reset the teacher salary, and where switching to billable could produce incorrect deductions or missing teacher records.

### Description
- Compute `chargedPrevMinutes` and `chargedNewMinutes` based on `CountsForBilling(...)` and apply a single delta `chargedPrevMinutes - chargedNewMinutes` to the student's `RemainingMinutes` so minutes are correctly restored or deducted.
- After mapping, normalize and persist the billed values by setting `report.Minutes = chargedNewMinutes` and `report.AttendStatueId = newStatusId` to avoid later inconsistencies.
- Recalculate the teacher record by setting `teacherReport.Minutes` and `teacherReport.CircleSallary` to zero for non‑billable statuses or to the recomputed salary for billable statuses, and create a new `TeacherReportRecord` when switching to a billable status and no record exists.
- Changes made in `OrbitsGeneralProject.BLL/CircleReportService/CircleReportBLL.cs` (refactor of the previous branching logic into the charged minutes model and added fallback creation of `TeacherReportRecord`).

### Testing
- Attempted to run `dotnet test Orbits.GeneralProject.sln`, but the `.NET SDK` is not available in the execution environment (`dotnet: command not found`), so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac6b6489883228659cb90c9959258)